### PR TITLE
Allow more track data to update if base title does not match meta title

### DIFF
--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -141,12 +141,17 @@ def combine_tracks(base, meta):
                 raise TrackCombineError(f"Disc {disc} track {num} does not exist.") from None
 
             # Use unidecode comparison when there are accents in the title
-            if (re_strip(unidecode(track["title"])) != re_strip(unidecode(btrack["title"]))
-                    and btrack["title"] is not None):
-                # Allow replacement if the base title is part of the meta title (e.g., remix scenario)
-                if (btrack["title"] and track["title"]
-                        and re_strip(unidecode(btrack["title"])) in re_strip(unidecode(track["title"]))):
-                    btrack["title"] = track["title"]
+            if (
+                    re_strip(unidecode(track["title"])) != re_strip(unidecode(btrack["title"]))
+                    and btrack["title"] is not None
+            ) and (
+                    btrack["title"]
+                    and track["title"]
+                    and re_strip(unidecode(btrack["title"])) in re_strip(unidecode(track["title"]))
+            ):
+
+            # Allow replacement if the base title is part of the meta title (e.g., remix scenario)
+                btrack["title"] = track["title"]
 
             if btrack["title"] is None:
                 btrack["title"] = track["title"]

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -147,22 +147,23 @@ def combine_tracks(base, meta):
                 if (btrack["title"] and track["title"]
                         and re_strip(unidecode(btrack["title"])) in re_strip(unidecode(track["title"]))):
                     btrack["title"] = track["title"]
-                else:
-                    continue
 
             if btrack["title"] is None:
                 btrack["title"] = track["title"]
+
             # Scraped title is the same than title when ignoring metadatas, and it contains accents and special
             # characters, prefer that one.
             if (re_strip(track["title"]) != re_strip(unidecode(track["title"]))
                     and re_strip(unidecode(track["title"])) == re_strip(unidecode(btrack["title"]))):
                 btrack["title"] = track["title"]
+
             base_artists = {(re_strip(a[0]), a[1]) for a in btrack["artists"]}
             btrack["artists"] = list(btrack["artists"])
             for a in track["artists"]:
                 if (re_strip(a[0]), a[1]) not in base_artists:
                     btrack["artists"].append(a)
             btrack["artists"] = check_for_artist_fragments(btrack["artists"])
+
             if track["explicit"]:
                 btrack["explicit"] = True
             if not btrack["format"]:


### PR DESCRIPTION
When combining track data, additional track metadata that was still pertinent  was being skipped, artists most importantly.
This tagger track combine update logic is seemingly the only way that base metadata is updated with the user selected source metadata.

### Test Case

```
> ARTISTS:
>>>  Lakeway [main]
```

```
base Title: No Escape (feat PAV4N)
meta Title: No Escape
```

- The local file tag `Artist` does not include the vocal artist `PAV4N` so it is not in meta `Artists` on initial base load
- The local file tag `Title`, and meta `track[artists]`, do include the vocal artist `PAV4N` 
- It was not currently added to the `Artists` on `combine_tracks` because:
  -  The meta Title does not equal or contain the base Title.

In this case the additional vocal artist was being dropped form the meta source and not updating the base.

### Fixed
```
> ARTISTS:
>>>  Lakeway [main]
>>>  PAV4N [guest]
```