### PR TITLE
Improve metadata combine from sources

### DIFF
--- a/salmon/constants.py
+++ b/salmon/constants.py
@@ -356,26 +356,25 @@ GENRE_LIST = {
     "vocal": {"Vocal"},
     "worldmusic": {"World Music"},
     # French to English
-    "musique electronique": {"Electronic"},
+    "musiqueelectronique": {"Electronic"},
     "electronique": {"Electronic"},
-    "musique classique": {"Classical"},
-    "hip-hop/rap": {"Hip Hop"},
-    "rap francais": {"French Rap"},
-    "musique du monde": {"World Music"},
-    "variete francaise": {"French Pop"},
-    "jazz vocal": {"Vocal Jazz"},
+    "musiqueclassique": {"Classical"},
+    "rapfrancais": {"French Rap"},
+    "musiquedumonde": {"World Music"},
+    "varietefrancaise": {"French Pop"},
+    "jazzvocal": {"Vocal Jazz"},
     # German to English
-    "elektronische musik": {"Electronic"},
-    "klassische musik": {"Classical"},
-    "zeitgenossische musik": {"Contemporary"},
+    "elektronischemusik": {"Electronic"},
+    "klassischemusik": {"Classical"},
+    "zeitgenossischemusik": {"Contemporary"},
     # Spanish to English
-    "musica electronica": {"Electronic"},
-    "musica clasica": {"Classical"},
+    "musicaelectronica": {"Electronic"},
+    "musicaclasica": {"Classical"},
     # Common mistranslations or variants
     "electronica": {"Electronic"},
-    "indie & alternative": {"Indie"},
-    "alternative & indie": {"Alternative"},
-    "r&b/soul": {"R&B"}
+    "indieandalternative": {"Indie"},
+    "alternativeandindie": {"Alternative"},
+    "randbsoul": {"R&B"}
 }
 
 ALLOWED_EXTENSIONS = {

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 from collections import defaultdict
 from itertools import chain
 
@@ -130,6 +131,15 @@ def sort_metadatas(metadatas):
     return sources
 
 
+def _extract_remixers_from_title(title):
+    # Match patterns like (Remixer Remix), (Remixer Mix), (Remixer Radio Mix), etc.
+    match = re.search(r"\((.*?)\s+(Club Mix|Radio Mix|Remix|Mix)\)", title, re.IGNORECASE)
+    if match:
+        remixer = match.group(1).strip()
+        return [(remixer, "remixer")]
+    return []
+
+
 def combine_tracks(base, meta):
     """Combine the metadata for the tracks of two different sources."""
     btracks = iter(chain.from_iterable([d.values() for d in base.values()]))
@@ -166,6 +176,10 @@ def combine_tracks(base, meta):
             for a in track["artists"]:
                 if (re_strip(a[0]), a[1]) not in base_artists:
                     btrack["artists"].append(a)
+            remixers = _extract_remixers_from_title(track["title"])
+            for remixer in remixers:
+                if (re_strip(remixer[0]), remixer[1]) not in base_artists:
+                    btrack["artists"].append(remixer)
             btrack["artists"] = check_for_artist_fragments(btrack["artists"])
 
             if track["explicit"]:

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -60,6 +60,7 @@ def combine_metadatas(*metadatas, base=None, source_url=None):  # noqa: C901
                 base = metadata
                 if base.get("url", False):
                     url_sources.add(get_source_from_link(base["url"]))
+                from_preferred_source = False
                 continue
 
             base["genres"] += metadata["genres"]
@@ -71,8 +72,6 @@ def combine_metadatas(*metadatas, base=None, source_url=None):  # noqa: C901
                     from_preferred_source
                 )
 
-            from_preferred_source = False
-
             if (
                 (not base["catno"] or not base["label"])
                 and metadata["label"]
@@ -81,7 +80,7 @@ def combine_metadatas(*metadatas, base=None, source_url=None):  # noqa: C901
                     not base["label"]
                     or any(w in metadata["label"] for w in base["label"].split())
                 )
-            ):
+            ) and (base["source"] != "WEB" or (base["source"] == "WEB" and from_preferred_source)):
                 base["label"] = metadata["label"]
                 base["catno"] = metadata["catno"]
 
@@ -115,6 +114,8 @@ def combine_metadatas(*metadatas, base=None, source_url=None):  # noqa: C901
                 base["rls_type"] = metadata["rls_type"]
             if not base["upc"]:
                 base["upc"] = metadata["upc"]
+
+            from_preferred_source = False
 
         if sources[pref] and "url" in sources[pref][0]:
             link_source = get_source_from_link(sources[pref][0]["url"])

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -7,7 +7,7 @@ from unidecode import unidecode
 from salmon.common import re_strip
 from salmon.errors import TrackCombineError
 from salmon.tagger.sources import METASOURCES
-from salmon.tagger.sources.base import generate_artists
+from salmon.tagger.sources.base import generate_artists, standardize_genres
 
 PREFERENCES = [
     "Tidal",
@@ -118,7 +118,7 @@ def combine_metadatas(*metadatas, base=None, source_url=None):  # noqa: C901
         del base["url"]
 
     base["artists"], base["tracks"] = generate_artists(base["tracks"])
-    base["genres"] = list(set(base["genres"]))
+    base["genres"] = standardize_genres(set(base["genres"]))
     return base
 
 

--- a/salmon/tagger/sources/qobuz.py
+++ b/salmon/tagger/sources/qobuz.py
@@ -328,7 +328,8 @@ class Scraper(QobuzBase, MetadataMixin):
         the release type that was explicitly provided by Qobuz.
         """
         # If Qobuz provided an explicit release type, respect it and keep it
-        if data["rls_type"] in ["Album", "EP", "Single", "Soundtrack", "Compilation"]:
+        # Might have to check which other rls_types from Qobuz are trustworthy
+        if data["rls_type"] in ["EP", "Single", "Soundtrack"]:
             return data["title"], data["rls_type"]
             
         # Otherwise, fall back to the base class's heuristics


### PR DESCRIPTION
* Standardize / deduplicate genres (no more genres with "Funk, Soul, Funk & Soul".
* Detect remixes from track titles during combine, and add the remixers as artists
* Improve the whole release type heuristics - Singles/EPs/Albums/Live Albums/Compilations/Anthologies should be better detected now
* Update trackumbers from preferred metadata source (the one with highest priority, or the one marked as rip source)
* Update catno only from preferred metadata source (the one with highest priority, or the one marked as rip source) for WEB
* Detect edition_title from title (and remove it from the actual title). It does impact metadata search, holding on using the edition_title in the searchstr of metadata search for now, until further testing.