### PR TITLE
Improve metadata scraping

### DIFF
--- a/salmon/constants.py
+++ b/salmon/constants.py
@@ -363,6 +363,7 @@ GENRE_LIST = {
     "musiquedumonde": {"World Music"},
     "varietefrancaise": {"French Pop"},
     "jazzvocal": {"Vocal Jazz"},
+    "alternatifetinde": {"Alternative"},
     # German to English
     "elektronischemusik": {"Electronic"},
     "klassischemusik": {"Classical"},

--- a/salmon/tagger/sources/base.py
+++ b/salmon/tagger/sources/base.py
@@ -129,9 +129,9 @@ class MetadataMixin(ABC):
             return title, "Anthology"
 
         # --- Track-based inference ---
-        if num_tracks <= 3 or len(base_titles) <= 3:
+        if num_tracks <= 3 or len(base_titles) <= 2:
             return title, "Single"
-        if num_tracks <= 7 and not data["rls_type"]:
+        if num_tracks <= 7 and (not data["rls_type"] or data["rls_type"] == "EP"):
             return title, "EP"
 
         # At that point, it should be a kind of album, but which one
@@ -140,7 +140,7 @@ class MetadataMixin(ABC):
             return title, "Remix"
         # If rls_type was actually passed (but not album, we have other possibilities), let's try to return that
         if rls_type and rls_type != "album":
-            return title, rls_type.title()
+            return title, data.get("rls_type")
 
         # An album with 6+ main artists is surely a compilation
         if len(main_artists) >= 6:

--- a/salmon/tagger/sources/base.py
+++ b/salmon/tagger/sources/base.py
@@ -201,13 +201,13 @@ class MetadataMixin(ABC):
     def process_label(self, data):
         def _compare(label, artist):
             label, artist = label.lower(), artist.lower()
-            return label == artist or re.sub(r" music$", "", label) == artist
+            return label == artist or label.startswith(artist)
 
         label = data.get("label", "")
 
         if isinstance(label, str):
             # Check for "Not On Label" or "Self-Released" in the label
-            if re.search(r"(not on label|self[- ]?released)", label, re.IGNORECASE):
+            if re.search(r"(not on label|no label|self[- ]?released)", label, re.IGNORECASE):
                 return "Self-Released"
 
             # Compare label to artist name

--- a/salmon/tagger/sources/deezer.py
+++ b/salmon/tagger/sources/deezer.py
@@ -69,7 +69,7 @@ class Scraper(DeezerBase, MetadataMixin):
 
     def process_label(self, data):
         if isinstance(data["label"], str) and any(
-            data["label"].lower() == a.lower() and i == "main"
+            data["label"].lower().startswith(a.lower()) and i == "main"
             for a, i in data["artists"]
         ):
             return "Self-Released"

--- a/salmon/tagger/sources/tidal.py
+++ b/salmon/tagger/sources/tidal.py
@@ -105,13 +105,14 @@ class Scraper(TidalBase, MetadataMixin):
 
         all_guests = all(a["type"] == "FEATURED" for a in artists)
         for artist in artists:
-            for a in re_split(artist["name"]):
-                feat = RE_FEAT.search(a)
-                if feat:
-                    for artist_ in re_split(feat[1]):
-                        result.append((unescape(artist_), "guest"))
-                        artist_set.add(unescape(artist_).lower())
-                    a = re.sub(feat[0] + "$", "", a).rstrip()
+            artist_without_feat = artist["name"]
+            feat = RE_FEAT.search(artist["name"])
+            if feat:
+                for artist_ in re_split(feat[1]):
+                    result.append((unescape(artist_), "guest"))
+                    artist_set.add(unescape(artist_).lower())
+                artist_without_feat = re.sub(re.escape(feat[0]) + "$", "", artist_without_feat).rstrip()
+            for a in re_split(artist_without_feat):
                 if artist["type"] in ROLES and unescape(a).lower() not in artist_set:
                     if unescape(a).lower() in remix_str:
                         result.append((unescape(a), "remixer"))

--- a/salmon/tagger/sources/tidal.py
+++ b/salmon/tagger/sources/tidal.py
@@ -78,7 +78,7 @@ class Scraper(TidalBase, MetadataMixin):
 
     def process_label(self, data):
         if isinstance(data["label"], str) and any(
-            data["label"].lower() == a.lower() and i == "main"
+            data["label"].lower().startswith(a.lower()) and i == "main"
             for a, i in data["artists"]
         ):
             return "Self-Released"

--- a/salmon/uploader/spectrals.py
+++ b/salmon/uploader/spectrals.py
@@ -354,7 +354,7 @@ def prompt_spectrals(spectral_ids, lossy_master, check_lma, force_prompt_lossy_m
                 "(space-separated list of IDs, \"0\" for none, \"*\" for all, or \"+\" for a randomized selection)",
                 fg="magenta"
             ),
-            default="+",
+            default="*" if lossy_master else "+",
         )
         if ids.strip() == "+":
             all_ids = list(spectral_ids.keys())


### PR DESCRIPTION
* Fix Tidal guest parsing for edge cases (Like Artist [guest1 & guest2] which was causing a parsing crash)
* Improve Self-released detection (no label, labels starting with the main artist name...)
* Improve (or try to) release_type heuristics