### PR TITLE
Remove auto generated cover images for scene and improve cover upload 

### DIFF
--- a/config.py.txt
+++ b/config.py.txt
@@ -29,6 +29,8 @@ PTPIMG_KEY = 'api_key'
 IMGUR_CLIENT_ID = 'imgur-client-id'
 IMGUR_CLIENT_SECRET = 'imgur-client-secret'
 IMGUR_REFRESH_TOKEN = 'imgur-client-refresh-token'
+# Remove downloaded cover images that are created in source folder, when one does not exist
+REMOVE_AUTO_DOWNLOADED_COVER_IMAGE = False
 
 # ===============================
 # METADATA SERVICES

--- a/salmon/tagger/cover.py
+++ b/salmon/tagger/cover.py
@@ -9,12 +9,26 @@ from salmon import config
 
 
 def download_cover_if_nonexistent(path, cover_url):
+    """
+    source folder path, url for cover image to be downloaded from
+    returns local source path of cover image, and whether image was downloaded
+    """
+    # use local file if matches filter
     for filename in os.listdir(path):
         if re.match(r"^(cover|folder)\.(jpe?g|png)$", filename, flags=re.IGNORECASE):
-            return
+            cover_path = os.path.join(path, filename)
+            click.secho(f"\nUsing existing cover image found: {filename}...", fg="yellow")
+            return cover_path, False
+    # use url provided
     if cover_url:
-        click.secho("\nDownloading cover image...", fg="yellow")
-        _download_cover(path, cover_url)
+        click.secho("\nDownloading Cover Image...", fg="yellow")
+        cover_path = _download_cover(path, cover_url)
+        if cover_path:
+            return cover_path, True
+    click.secho(
+        "\nNo existing Cover Image found in Source Folder, no Cover Image downloaded", fg="red"
+    )
+    return None, None
 
 
 def _download_cover(path, cover_url):
@@ -24,7 +38,8 @@ def _download_cover(path, cover_url):
     stream = requests.get(cover_url, stream=True, headers=headers)
 
     if stream.status_code < 400:
-        cover_path = os.path.join(path, f"{c}over{ext}")
+        cover_image_filename = c + "over" + ext
+        cover_path = os.path.join(path, cover_image_filename)
         with open(cover_path, "wb") as f:
             for chunk in stream.iter_content(chunk_size=5096):
                 if chunk:
@@ -34,5 +49,8 @@ def _download_cover(path, cover_url):
         if not kind or kind.mime not in ["image/jpeg", "image/png"]:
             os.remove(cover_path)
             click.secho("\nFailed to download cover image (ERROR file is not an image [JPEG, PNG])", fg="red")
+        click.secho(f"Cover image downloaded: {cover_image_filename} ", fg="yellow")
+        return cover_path
     else:
         click.secho(f"\nFailed to download cover image (ERROR {stream.status_code})", fg="red")
+        return None

--- a/salmon/uploader/upload.py
+++ b/salmon/uploader/upload.py
@@ -9,7 +9,6 @@ from salmon import config
 from salmon.common import str_to_int_if_int
 from salmon.constants import ARTIST_IMPORTANCES, RELEASE_TYPES
 from salmon.errors import RequestError
-from salmon.images import upload_cover
 from salmon.sources import SOURCE_ICONS
 from salmon.tagger.sources import METASOURCES
 from salmon.uploader.spectrals import (
@@ -36,8 +35,6 @@ def prepare_and_upload(
 ):
     """Wrapper function for all the data compiling and processing."""
     if not group_id:
-        if not cover_url:
-            cover_url = upload_cover(path, scene=metadata['scene'])
         data = compile_data_new_group(
             path,
             metadata,


### PR DESCRIPTION
- Removes logic from `upload_cover` specific for scene and existing files
  - Method now just uploads a provided image to third party provider
- Moves cover image creation further down in upload process
  - Less need to handle rollbacks
  - Better handling of folder renaming
  - Helps clean up huge method
- Removes generated cover image if `--scene` or config option set true
- Removes duplicate `upload_cover` call when preparing data for each Tracker
  - Original code[ mentions removing](https://github.com/smokin-salmon/smoked-salmon/commit/9c49c04afbfb68f8b61e32d228e17a4f702e715a#diff-fa4a2a022cd03d3fbd9951841900f7d8c4dca49b807f37ad54887da0c2c46ce7R253) this duplication. Doesn't seem necessary.

Fixes #42 