### PR TITLE
Add windows input fallback

### DIFF
--- a/salmon/common/__init__.py
+++ b/salmon/common/__init__.py
@@ -51,17 +51,12 @@ class Prompt:
 
     async def __call__(self, msg, end="\n", flush=False):
         if not self.reader_added:
+            print(msg, end=end, flush=flush)
             try:
                 loop.add_reader(sys.stdin, self.got_input)
                 self.reader_added = True
             except NotImplementedError:
-                print(msg, end=end, flush=flush)
                 return input()
-
-        if self.reader_added:
-            print(msg, end=end, flush=flush)
-            return (await self.q.get()).rstrip("\n")
-        return ""
 
 
 prompt_async = Prompt()

--- a/salmon/common/__init__.py
+++ b/salmon/common/__init__.py
@@ -51,10 +51,17 @@ class Prompt:
 
     async def __call__(self, msg, end="\n", flush=False):
         if not self.reader_added:
-            loop.add_reader(sys.stdin, self.got_input)
-            self.reader_added = True
-        print(msg, end=end, flush=flush)
-        return (await self.q.get()).rstrip("\n")
+            try:
+                loop.add_reader(sys.stdin, self.got_input)
+                self.reader_added = True
+            except NotImplementedError:
+                print(msg, end=end, flush=flush)
+                return input()
+
+        if self.reader_added:
+            print(msg, end=end, flush=flush)
+            return (await self.q.get()).rstrip("\n")
+        return ""
 
 
 prompt_async = Prompt()


### PR DESCRIPTION
`loop.add_reader` is not windows compatible.

When an exception occurs, fall back to simple input()