### PR TITLE
Identify Self-Released label when set from base

### DIFF
--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -8,7 +8,7 @@ from unidecode import unidecode
 from salmon.common import re_strip
 from salmon.errors import TrackCombineError
 from salmon.tagger.sources import METASOURCES
-from salmon.tagger.sources.base import generate_artists, standardize_genres
+from salmon.tagger.sources.base import determine_label_type, generate_artists, standardize_genres
 
 PREFERENCES = [
     "Tidal",
@@ -128,6 +128,7 @@ def combine_metadatas(*metadatas, base=None, source_url=None):  # noqa: C901
 
     base["artists"], base["tracks"] = generate_artists(base["tracks"])
     base["genres"] = standardize_genres(set(base["genres"]))
+    base["label"] = determine_label_type(base["label"], base["artists"])
     return base
 
 


### PR DESCRIPTION
We standardize the label after combining the metadata with the base tags.