### PR TITLE
Fix Encoding in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 RUN ARCH=$(dpkg --print-architecture) && \
     apt-get update && apt-get install -y --no-install-recommends \
     sox flac mp3val curl nano vim-tiny \
-    ca-certificates && rm -rf /var/lib/apt/lists/* && \
+    ca-certificates lame ffmpeg && rm -rf /var/lib/apt/lists/* && \
     if [ "$ARCH" = "amd64" ]; then \
         wget https://github.com/shssoichiro/oxipng/releases/download/v9.1.4/oxipng_9.1.4-1_amd64.deb && \
         dpkg -i oxipng_9.1.4-1_amd64.deb; \


### PR DESCRIPTION
title says it, confirmed container still builds and fixes #68 for V0 encoding

ffmpeg is also required for MP3 320kbps encodes, V0 is fine with just lame. I can add ffmpeg if you'd like but figure you'd rather it be"fixed" it to use just lame instead of using lame through ffmpeg

https://github.com/smokin-salmon/smoked-salmon/blob/master/salmon/converter/transcoding.py#L16

**Reccomended commands from RED Wiki**
```
lame -V0 -k --vbr-new infile outfile
lame -b <bit rate> infile outfile
```

**V0 Encoding**
```
salmon transcode '/data/Artist - song' -b v0
patch1-workflow: Pulling from milkers69/smoked-salmon
Digest: sha256:12405ee67aa6b2fce51c866af0f6bdf2036afde7029dd9b388a41a9376394cef
Status: Image is up to date for ghcr.io/milkers69/smoked-salmon:patch1-workflow
Local Version: 0.9.3.5
No new version available.

Transcoding Artist - song [0 left to transcode]
Copied 01 Full.png
Copied 01 Zoom.png
Copied cover.jpg
```

**CBR320 Encoding**
```
salmon transcode '/data/Artist - song' -b 320
patch1-workflow: Pulling from milkers69/smoked-salmon
Digest: sha256:12405ee67aa6b2fce51c866af0f6bdf2036afde7029dd9b388a41a9376394cef
Status: Image is up to date for ghcr.io/milkers69/smoked-salmon:patch1-workflow
Local Version: 0.9.3.5
No new version available.

Transcoding /data/Artist - song [0 left to transcode]
Copied 01 Full.png
Copied 01 Zoom.png
Copied cover.jpg
Error transcoding a file, error 127:
/bin/sh: 1: ffmpeg: not found

Aborted!
```

Just found this repo today, thanks for maintaining an up to date version of this