### PR TITLE
Fix strict python version (3.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.9.3.6.1"
 description = "An uploading script for Gazelle-based music trackers."
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = "==3.11"
 dependencies = [
     "requests>=2.31.0",
     "click>=8.1.7",


### PR DESCRIPTION
To use the bencoder.pyx prebuild wheel (https://pypi.org/project/bencoder.pyx/3.0.1/#files)