### PR TITLE
Beatport is back

### DIFF
--- a/salmon/search/__init__.py
+++ b/salmon/search/__init__.py
@@ -14,7 +14,7 @@ from salmon.common import (
 )
 from salmon.search import (
     bandcamp,
-    #beatport,
+    beatport,
     deezer,
     discogs,
     itunes,
@@ -30,7 +30,7 @@ SEARCHSOURCES = {
     "iTunes": itunes,
     "Junodownload": junodownload,
     "Discogs": discogs,
-    #"Beatport": beatport,
+    "Beatport": beatport,
     "Qobuz": qobuz,
     "Tidal": tidal,
     "Deezer": deezer,

--- a/salmon/sources/__init__.py
+++ b/salmon/sources/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from salmon.sources.bandcamp import BandcampBase
-#from salmon.sources.beatport import BeatportBase
+from salmon.sources.beatport import BeatportBase
 from salmon.sources.deezer import DeezerBase
 from salmon.sources.discogs import DiscogsBase
 from salmon.sources.itunes import iTunesBase
@@ -11,7 +11,7 @@ from salmon.sources.tidal import TidalBase
 
 SOURCE_ICONS = {
     "Bandcamp": "https://ptpimg.me/91oo89.png",
-    #"Beatport": "https://ptpimg.me/5hwjpv.png",
+    "Beatport": "https://ptpimg.me/5hwjpv.png",
     "Deezer": "https://ptpimg.me/m265v2.png",
     "Discogs": "https://ptpimg.me/13y32k.png",
     "iTunes": "https://ptpimg.me/0z2x90.png",

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -141,11 +141,21 @@ def sort_metadatas(metadatas):
 
 
 def _extract_remixers_from_title(title):
+    # Mix types that don't indicate a remixer when alone
+    common_mix_types = {
+        "original", "extended", "radio", "club", "instrumental",
+        "acoustic", "album", "vocal", "main", "dub", "edit"
+    }
+    
     # Match patterns like (Remixer Remix), (Remixer Mix), (Remixer Radio Mix), etc.
-    match = re.search(r"\((.*?)\s+(Club Mix|Radio Mix|Remix|Mix)\)", title, re.IGNORECASE)
+    # Also matches compound mix types like "Vocal Mix", "Club Mix", etc.
+    match = re.search(r"\((.*?)\s+(?:Club|Radio|Vocal|Dub|Extended)?\s*(?:Remix|Mix|Edit)\)", title, re.IGNORECASE)
     if match:
-        remixer = match.group(1).strip()
-        return [(remixer, "remixer")]
+        remixers = match.group(1).strip()
+        # Split on common delimiters and strip each name
+        remixer_list = [r.strip() for r in re.split(r'\s*(?:&|,|/|;|\+)\s*', remixers)]
+        # Filter out common mix types and return remaining as remixers
+        return [(r, "remixer") for r in remixer_list if r.lower() not in common_mix_types]
     return []
 
 

--- a/salmon/tagger/sources/__init__.py
+++ b/salmon/tagger/sources/__init__.py
@@ -5,7 +5,7 @@ import click
 from salmon.errors import ScrapeError
 from salmon.tagger.sources import (
     bandcamp,
-    #beatport,
+    beatport,
     deezer,
     discogs,
     itunes,
@@ -21,7 +21,7 @@ METASOURCES = {
     "Junodownload": junodownload,
     "Deezer": deezer,
     "Discogs": discogs,
-    #"Beatport": beatport,
+    "Beatport": beatport,
     "Qobuz": qobuz,
     "Tidal": tidal,
     "Bandcamp": bandcamp,  # Must be last due to the catch-all nature of its URLs.

--- a/salmon/tagger/sources/base.py
+++ b/salmon/tagger/sources/base.py
@@ -389,7 +389,7 @@ def append_remixers_to_track_titles(data):
     for dnum, disc in data.items():
         for tnum, track in disc.items():
             remix_artists = [a for a, i in track["artists"] if i == "remixer"]
-            if "Remix" not in track["title"]:
+            if not any(x in track["title"] for x in ("Remix", "Mix")):
                 if len(remix_artists) >= config.VARIOUS_ARTIST_THRESHOLD:
                     data[dnum][tnum]["title"] += " (Remixed)"
                 elif remix_artists:


### PR DESCRIPTION
- Add back beatport as metadata provider
- Fix adding "Extended", "Original" as remixers
- Fix adding the remixer in titles if it already contains it (it was previously only checking for "Mix" in title, now it also checks for "Remix"; might need more tuning)