### PR TITLE
Use beatport track_id instead of label_track_identifier

### DIFF
--- a/salmon/tagger/sources/beatport.py
+++ b/salmon/tagger/sources/beatport.py
@@ -82,7 +82,7 @@ class Scraper(BeatportBase, MetadataMixin):
         try:
             track_list = sorted(
                 soup["state"]["data"]["results"],
-                key=lambda x: int(x["label_track_identifier"]) if x["label_track_identifier"] is not None else 0
+                key=lambda x: int(x["id"]) if x["id"] is not None else 0
             )
             for i, track in enumerate(track_list, 1):
                 track_num = str(i)


### PR DESCRIPTION
For numbering tracks in the correct order