### PR TITLE
Fix RELEASE_TYPES enum

### DIFF
--- a/salmon/constants.py
+++ b/salmon/constants.py
@@ -46,14 +46,15 @@ RELEASE_TYPES = {
     "Anthology": 6,
     "Compilation": 7,
     "Single": 9,
+    "Demo": 10,
     "Live album": 11,
+    "Split": 12,
     "Remix": 13,
     "Bootleg": 14,
     "Interview": 15,
     "Mixtape": 16,
-    "Demo": 17,
+    "DJ Mix": 17,
     "Concert Recording": 18,
-    "DJ Mix": 19,
     "Unknown": 21,
 }
 


### PR DESCRIPTION
Grabbed the JSON form one of every release type from OPS to check the `releaseType` tag.
I first noticed this issue when I attempted to upload a "Demo" that erroneously got tagged as a "DJ set"
Also added an option for a "Split"