### PR TITLE
Add health command to show state of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Installing with pip is not recommended because uv (and pipx) manage python versi
 	salmon checkconf
 	```
 
+5. Use the `health` command to verify that all necesasary command line dependencies are installed:
+
+	```
+	salmon health
+	```
+
 ### 🐳 Docker Installation
 A Docker image is generated per release.
 **Disclaimer**: I am not actively using the docker image myself, feedback is appreciated regarding that guide.
@@ -135,6 +141,11 @@ salmon
 To test the connection to the trackers, run:
 ```bash
 salmon checkconf
+```
+
+To check the status of salmon's command line and config dependencies, run:
+```bash
+salmon health
 ```
 
 To start an upload (with the WEB source):

--- a/salmon/config/__init__.py
+++ b/salmon/config/__init__.py
@@ -12,7 +12,7 @@ APPNAME = "smoked-salmon"
 root_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
-def _get_user_cfg_path():
+def get_user_cfg_path():
     return os.path.join(user_config_dir(APPNAME), "config.toml")
 
 
@@ -32,7 +32,7 @@ def _try_creating_config(src, dest):
 
 
 def find_config_path():
-    config_dir_path = _get_user_cfg_path()
+    config_dir_path = get_user_cfg_path()
     root_config_path = os.path.join(root_path, "config.toml")
 
     # You can put a config.toml in the root directory for development purposes
@@ -50,7 +50,7 @@ def setup_config():
     try:
         path = find_config_path()
     except Exception:
-        cfg_path = _get_user_cfg_path()
+        cfg_path = get_user_cfg_path()
         attempted_default_cfg = os.path.join(os.path.dirname(cfg_path), "config.default.toml")
 
         click.secho(f"Could not find configuration path at {cfg_path}.", fg="red")


### PR DESCRIPTION
Example output:

```
Config path: /home/resu/.config/smoked-salmon/config.toml
DB path: /home/resu/.local/share/smoked-salmon/smoked.db

Required Dependencies:
curl ✓
ffmpeg ✓
flac ✓
git ✓
lame ✓
mp3val ✓
oxipng ✓
sox ✓
unzip ✓

Optional Dependencies:
cambia ✘
puddletag ✓
feh ✘
```

fixes #109 