### PR TITLE
Two fixes in foldername.py

### DIFF
--- a/salmon/tagger/foldername.py
+++ b/salmon/tagger/foldername.py
@@ -34,16 +34,15 @@ def rename_folder(path, metadata, auto_rename, check=True):
         click.secho("\nRenaming folder...", fg="cyan", bold=True)
         click.echo(f"Old folder name        : {old_base}")
         click.echo(f"New pending folder name: {new_base}")
-        if not auto_rename and not click.confirm(
+
+        user_rename_choice = click.confirm(
             click.style(
                 "\nWould you like to replace the original folder name?",
                 fg="magenta"                
             ),
-            default=True,
-        ):
-            return path
+            default=True)
 
-        new_base = _edit_folder_interactive(new_base, auto_rename)
+        new_base = _edit_folder_interactive(new_base, auto_rename) if auto_rename or user_rename_choice else old_base
 
     new_path = os.path.join(cfg.directory.download_directory, new_base)
     if os.path.isdir(new_path) and not os.path.samefile(path, new_path):


### PR DESCRIPTION
Fix 1. When choosing "no" in the rename folder dialog, it would not move the folder to the torrent directory. I don't know if this was intentional behavior or not, but it is kind of annoying. I would like some comments on this

Fix 2. Instead of erroring on hardlink failure, try softlinking.
    - There's a function in pathlib that would mean you don't have to use shutil and also
    - perhaps the hardlink option could be removed if other software just does hardlink_to then falls back to copying. I dunno tho.