### PR TITLE
Skip log check if cambia is not on the path

### DIFF
--- a/salmon/checks/logs.py
+++ b/salmon/checks/logs.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 
 import click
@@ -36,6 +37,12 @@ def _calculate_file_crc(filepath, _ = None):
 
 def check_log_cambia(logpath, basepath):
     """Check a log file using Cambia."""
+
+    path_has_cambia = shutil.which("cambia")
+    if not path_has_cambia:
+        click.secho("Cambia is not on the system PATH. Skipping log check!", fg="yellow")
+        return
+
     try:
         cambia_output = json.loads(
             subprocess.check_output(


### PR DESCRIPTION
Please tell me if this is desired behavior, or if the user should know to do --skip-log-check