### PR TITLE
Make default tracker field not required

### DIFF
--- a/salmon/config/validations.py
+++ b/salmon/config/validations.py
@@ -83,7 +83,7 @@ class GazelleTrackerSettings(BaseStruct):
 class Tracker(BaseStruct):
     red: GazelleTrackerSettings | None = None
     ops: GazelleTrackerSettings | None = None
-    default_tracker: Literal["RED", "OPS"] = "RED"
+    default_tracker: Literal["RED", "OPS"] | None = None
 
     def __post_init__(self):
         if (self.red is None) and (self.ops is None):


### PR DESCRIPTION
Fixes #123

There was already code to handle this scenario that I didn't see (see function choose_tracker_first_time in salmon/trackers/__init__.py).