### PR TITLE
Add a hint to the metadata results if a release is saved in the users discogs collection

### DIFF
--- a/salmon/search/base.py
+++ b/salmon/search/base.py
@@ -27,7 +27,7 @@ class SearchMixin(ABC):
         country_code=None,
         explicit=False,
         clean=False,
-        additional_info=None
+        additional_info=None,
     ):
         """
         Take the attributes of a search result and format them into a
@@ -52,5 +52,5 @@ class SearchMixin(ABC):
         # Add any additional information that might be helpful to identify the release
         if additional_info:
             result += f" {additional_info}"
-        
+
         return result

--- a/salmon/search/base.py
+++ b/salmon/search/base.py
@@ -27,6 +27,7 @@ class SearchMixin(ABC):
         country_code=None,
         explicit=False,
         clean=False,
+        additional_info=None
     ):
         """
         Take the attributes of a search result and format them into a
@@ -48,5 +49,8 @@ class SearchMixin(ABC):
             result = click.style("[C] ", fg="cyan", bold=True) + result
         if country_code:
             result = f"[{country_code}] " + result
-
+        # Add any additional information that might be helpful to identify the release
+        if additional_info:
+            result += f" {additional_info}"
+        
         return result

--- a/salmon/search/discogs.py
+++ b/salmon/search/discogs.py
@@ -1,4 +1,5 @@
 import re
+
 import click
 
 from salmon.search.base import IdentData, SearchMixin
@@ -32,8 +33,8 @@ class Searcher(DiscogsBase, SearchMixin):
 
             # Check if the release is in the user's discogs collection and add a hint if so
             release_in_user_collection = rls["user_data"]["in_collection"]
-            collection_text = " " + click.style("IN COLLECTION", bg="red", bold=True) if release_in_user_collection else None
-                
+            collection_text = click.style("IN COLLECTION", bg="red", bold=True) if release_in_user_collection else None
+
             releases[rls["id"]] = (
                 IdentData(artists, title, year, None, source),
                 self.format_result(artists, title, edition, ed_title=ed_title, additional_info=collection_text),

--- a/salmon/search/discogs.py
+++ b/salmon/search/discogs.py
@@ -1,4 +1,5 @@
 import re
+import click
 
 from salmon.search.base import IdentData, SearchMixin
 from salmon.sources import DiscogsBase
@@ -29,9 +30,13 @@ class Searcher(DiscogsBase, SearchMixin):
             else:
                 edition += " Not On Label"
 
+            # Check if the release is in the user's discogs collection and add a hint if so
+            release_in_user_collection = rls["user_data"]["in_collection"]
+            collection_text = " " + click.style("IN COLLECTION", bg="red", bold=True) if release_in_user_collection else None
+                
             releases[rls["id"]] = (
                 IdentData(artists, title, year, None, source),
-                self.format_result(artists, title, edition, ed_title=ed_title),
+                self.format_result(artists, title, edition, ed_title=ed_title, additional_info=collection_text),
             )
             if len(releases) == limit:
                 break


### PR DESCRIPTION
This change helps to quickly identify releases when working with discogs collections.

<img width="1533" height="106" alt="grafik" src="https://github.com/user-attachments/assets/2b46f5ad-7a6c-4441-9aca-3535844e696a" />
