### PR TITLE
Fix broken deluge URL parser

### DIFF
--- a/salmon/uploader/torrent_client.py
+++ b/salmon/uploader/torrent_client.py
@@ -221,7 +221,7 @@ class TorrentClientGenerator:
         if client in ["qbittorrent", "rutorrent"]:
             kwargs["url"] = f"{scheme[1]}://{netloc}{parsed.path}"
         else:
-            kwargs["scheme"] = scheme[1]
+            kwargs["scheme"] = scheme[-1]  # Use last element of scheme to support deluge and transmission
             kwargs["host"], kwargs["port"] = netloc.split(":")
             kwargs["port"] = int(kwargs["port"])
 


### PR DESCRIPTION
The parsing logic for deluge & transmission URLs expected the deluge URLs to have the format `"deluge+scheme://username:password@host:part"` instead of the documented `"deluge://username:password@host:port"`.

This lead to an error when trying to upload torrents to deluge: `"Failed to configure local uploader: list index out of range"`