### PR TITLE
add imgbb.com uploader

### DIFF
--- a/data/config.default.toml
+++ b/data/config.default.toml
@@ -28,7 +28,7 @@ dottorrents_dir = '.torrents'
 # ===============================
 # IMAGE UPLOAD SETTINGS
 # ===============================
-# Image hosters: ptpimg, ptscreens, oeimg, catbox, emp (not tested recently)
+# Image hosters: ptpimg, ptscreens, oeimg, imgbb, catbox, emp (not tested recently)
 [image]
 image_uploader = "ptpimg"
 cover_uploader = "ptpimg"
@@ -40,6 +40,8 @@ ptpimg_key = 'api_key'
 ptscreens_key = 'api_key'
 # oeimg API key (log into imgoe, settings, API)
 oeimg_key = 'api_key'
+# imgbb API key (log into imgbb, about, API)
+imgbb_key = 'api_key'
 
 # Set to true to remove downloaded cover images that are created in source folder, when one does not exist
 # remove_auto_downloaded_cover_image = false

--- a/salmon/config/validations.py
+++ b/salmon/config/validations.py
@@ -24,7 +24,7 @@ class Directory(BaseStruct):
             raise ValueError("tmp_dir is not a valid directory")
 
 
-ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "emp"]
+ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "emp", "imgbb"]
 
 
 class ImageUploader(BaseStruct):
@@ -34,6 +34,7 @@ class ImageUploader(BaseStruct):
     ptpimg_key: str | None = None
     ptscreens_key: str | None = None
     oeimg_key: str | None = None
+    imgbb_key: str | None = None
     remove_auto_downloaded_cover_image: bool = False
     auto_compress_cover: bool = False
 
@@ -45,6 +46,8 @@ class ImageUploader(BaseStruct):
             raise ValueError("PTScreens key not specified")
         if "oeimg" in uploader_selections and self.oeimg_key is None:
             raise ValueError("oeimage key not specified")
+        if "imgbb" in uploader_selections and self.imgbb_key is None:
+            raise ValueError("imgbb key not specified")
 
 
 class TidalSettings(BaseStruct):

--- a/salmon/images/__init__.py
+++ b/salmon/images/__init__.py
@@ -8,7 +8,7 @@ from salmon import cfg
 from salmon.common import AliasedCommands, commandgroup
 from salmon.database import DB_PATH
 from salmon.errors import ImageUploadFailed
-from salmon.images import catbox, emp, oeimg, ptpimg, ptscreens
+from salmon.images import catbox, emp, imgbb, oeimg, ptpimg, ptscreens
 
 loop = asyncio.get_event_loop()
 
@@ -18,6 +18,7 @@ HOSTS = {
     "catbox": catbox,
     "ptscreens": ptscreens,
     "oeimg": oeimg,
+    "imgbb": imgbb,
 }
 
 

--- a/salmon/images/imgbb.py
+++ b/salmon/images/imgbb.py
@@ -1,0 +1,22 @@
+import requests
+
+from salmon import cfg
+from salmon.errors import ImageUploadFailed
+from salmon.images.base import BaseImageUploader
+
+HEADERS = {"referer": "https://imgbb.com/", "User-Agent": cfg.upload.user_agent}
+
+
+class ImageUploader(BaseImageUploader):
+    def _perform(self, file_, ext):
+        data = {"key": cfg.image.imgbb_key}
+        url = "https://api.imgbb.com/1/upload"
+        files = {"image": file_}
+        resp = requests.post(url, headers=HEADERS, data=data, files=files)
+        if resp.status_code == requests.codes.ok:
+            try:
+                return resp.json()["data"]["url"], None
+            except (ValueError, KeyError, TypeError) as e:
+                raise ImageUploadFailed(f"Failed decoding body:\n{e}\n{resp.content}") from e
+        else:
+            raise ImageUploadFailed(f"Failed. Status {resp.status_code}:\n{resp.content}")


### PR DESCRIPTION
[This issue](https://github.com/smokin-salmon/smoked-salmon/issues/192#issue-3502624835) inspired me to look into add another image hoster while getting to know the codebase.

Using their API I implemented it almost identical to the other uploaders.

I also fond a few smelly pieces of code with how the different hosters are handled during configuration & validation (`salmon/config/validations.py:L27,41-50`) and the piece of code that matches the config value/cmdline argument to the actual implementation (`salmon/images/__init__.py:L14-22`).
How does this project handle such improvements?