### PR TITLE
adding imgbox as img hoster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "ffmpeg-python>=0.2.0",
     "humanfriendly>=10.0",
     "pillow>=11.3.0",
+    "pyimgbox>=1.0.7",
 ]
 
 [project.scripts]

--- a/salmon/config/validations.py
+++ b/salmon/config/validations.py
@@ -24,7 +24,7 @@ class Directory(BaseStruct):
             raise ValueError("tmp_dir is not a valid directory")
 
 
-ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "emp", "imgbb"]
+ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "emp", "imgbb", "imgbox"]
 
 
 class ImageUploader(BaseStruct):

--- a/salmon/images/__init__.py
+++ b/salmon/images/__init__.py
@@ -8,7 +8,7 @@ from salmon import cfg
 from salmon.common import AliasedCommands, commandgroup
 from salmon.database import DB_PATH
 from salmon.errors import ImageUploadFailed
-from salmon.images import catbox, emp, imgbb, oeimg, ptpimg, ptscreens
+from salmon.images import catbox, emp, imgbb, imgbox, oeimg, ptpimg, ptscreens
 
 loop = asyncio.get_event_loop()
 
@@ -19,6 +19,7 @@ HOSTS = {
     "ptscreens": ptscreens,
     "oeimg": oeimg,
     "imgbb": imgbb,
+    "imgbox": imgbox,
 }
 
 

--- a/salmon/images/imgbox.py
+++ b/salmon/images/imgbox.py
@@ -1,0 +1,78 @@
+import asyncio
+import contextlib
+
+import pyimgbox
+
+from salmon import cfg
+from salmon.errors import ImageUploadFailed
+from salmon.images.base import BaseImageUploader
+
+
+class ImageUploader(BaseImageUploader):
+    """
+    Uploads a single image to imgbox.com using the pyimgbox library.
+    Returns the direct URL to the full-size image by default, or the thumbnail URL
+    if USE_THUMBNAIL is set to True.
+    """
+
+    THUMB_WIDTH = 350  # Default thumbnail width in pixels (imgbox default)
+    USE_THUMBNAIL = False  # False → full-size URL; True → thumbnail URL
+
+    def upload_file(self, filename: str) -> tuple[str, str | None]:
+        """
+        Public entry point required by BaseImageUploader.
+        Opens the file at the given path, ensures it is properly closed after upload,
+        and returns the resulting image URL.
+        Args:
+            filename: Path to the image file on disk.
+        Returns:
+            Tuple of (direct_image_url_or_thumbnail_url, None)
+        """
+        with contextlib.ExitStack():
+            return self._perform(filename)
+
+    def _perform(self, filename: str) -> tuple[str, str | None]:
+        """
+        Executes the actual upload in a new asyncio event loop.
+        Creates a temporary event loop since this method is called synchronously,
+        runs the async upload, and cleans up properly.
+        Args:
+            filename: Path to the image file to upload.
+        Returns:
+            Tuple containing the final image/thumbnail URL and None.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        try:
+            url = loop.run_until_complete(self._upload_single(filename))
+            return url, None
+        except Exception as e:
+            raise ImageUploadFailed(f"ImgBox upload failed: {e}") from e
+        finally:
+            loop.close()
+
+    async def _upload_single(self, filename: str) -> str:
+        """
+        Asynchronously uploads a single image file to imgbox.com.
+        Uses a temporary single-image gallery titled "salmon-upload".
+        The gallery is automatically cleaned up on exit.
+        Args:
+            filename: Filesystem path to the image to upload.
+        Returns:
+            The direct full-size image URL or thumbnail URL based on USE_THUMBNAIL.
+        Raises:
+            ImageUploadFailed: If the upload fails or returns an error.
+        """
+        async with pyimgbox.Gallery(
+            title="salmon-upload",
+            thumb_width=self.THUMB_WIDTH,
+            adult=getattr(cfg.upload, "imgbox_adult", False),
+        ) as gallery:
+            submission = await gallery.upload(filepath=filename)
+
+            if not submission["success"]:
+                error_msg = submission.get("error", "Unknown error")
+                raise ImageUploadFailed(f"ImgBox upload failed for {filename}: {error_msg}")
+
+            return submission["thumbnail_url"] if self.USE_THUMBNAIL else submission["image_url"]

--- a/uv.lock
+++ b/uv.lock
@@ -958,6 +958,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyimgbox"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/6b/520e8df8d5337725f8f2cb8328996b0963a979eb7e92609e299db3cba251/pyimgbox-1.0.7.tar.gz", hash = "sha256:27cd9832fe97dfa73713031c5d5be7ea95c53212ae8dfb71dfd0bf60fb0ec2aa", size = 24275, upload-time = "2023-11-28T14:16:19.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d4/1ec5e69c43c243952f125fa6485dfbaf7a6a978846d643721dcbbd339e87/pyimgbox-1.0.7-py3-none-any.whl", hash = "sha256:b6098e4f6c5e1da9cda7a28b27216e7e0db1c0a6ca650a56d488f3ef2cdbd0ea", size = 25584, upload-time = "2023-11-28T14:16:17.684Z" },
+]
+
+[[package]]
 name = "pyoxipng"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1109,6 +1122,7 @@ dependencies = [
     { name = "pillow" },
     { name = "platformdirs" },
     { name = "pycambia" },
+    { name = "pyimgbox" },
     { name = "pyoxipng" },
     { name = "pyperclip" },
     { name = "qbittorrent-api" },
@@ -1149,6 +1163,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pycambia", specifier = ">=0.1.0" },
+    { name = "pyimgbox", specifier = ">=1.0.7" },
     { name = "pyoxipng", specifier = ">=9.1.0" },
     { name = "pyperclip", specifier = ">=1.8.2" },
     { name = "qbittorrent-api", specifier = ">=2025.2.0" },


### PR DESCRIPTION
im not sure why the whole file thinks it changed for 

salmon/images/__init__.py

but I added line 22 the imgbox import. 

Tested locally with 


`salmon images up ~/torrents/img.jpg --image-host imgbox`


imgbox has no official API, so no need for config key. Can specify `imgbox` in the config `*_uploader` configs. 
pyimgbox is a library that allows us to upload to imgbox and get the urls back. 