### PR TITLE
Only keep Music requests

### DIFF
--- a/salmon/uploader/request_checker.py
+++ b/salmon/uploader/request_checker.py
@@ -36,7 +36,7 @@ def get_request_results(gazelle_site, searchstrs):
         )["results"]:
             if req not in results:
                 results.append(req)
-    return results
+    return [item for item in results if item["categoryName"] > 'Music']
 
 
 def print_request_results(gazelle_site, results, searchstr):


### PR DESCRIPTION
This fixes an issue where we try to access the list of artists when the list is empty for non-music requests. A better solution is to filter the results at fetching but didn't see the option in the API.