### PR TITLE
Fix import-time asyncio loop usage for Python 3.14 compatibility

### DIFF
--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -36,8 +36,6 @@ from salmon.uploader.spectrals import (
 )
 from salmon.uploader.upload import generate_source_links
 
-loop = asyncio.get_event_loop()
-
 
 @commandgroup.command()
 @click.argument("path", type=click.Path(exists=True, file_okay=False, resolve_path=True), nargs=1)
@@ -74,7 +72,7 @@ def descgen(urls):
     if not urls:
         return click.secho("You must specify at least one URL", fg="red")
     tasks = [run_metadata(url, return_source_name=True) for url in urls]
-    metadatas = loop.run_until_complete(asyncio.gather(*tasks))
+    metadatas = asyncio.run(asyncio.gather(*tasks))
     metadata = clean_metadata(combine_metadatas(*((s, m) for m, s in metadatas)))
     remove_various_artists(metadata["tracks"])
 
@@ -162,7 +160,7 @@ def checkspecs(tracker, torrent_id, path):
         raise click.Abort
     tracker = salmon.trackers.validate_tracker(None, "tracker", tracker)
     gazelle_site = salmon.trackers.get_class(tracker)()
-    req = loop.run_until_complete(gazelle_site.request("torrent", id=torrent_id))
+    req = asyncio.run(gazelle_site.request("torrent", id=torrent_id))
     path = os.path.join(path, html.unescape(req["torrent"]["filePath"]))
     source_url = None
     source = req["torrent"]["media"]
@@ -302,7 +300,7 @@ def _test_metadata_sources():
 
             # For a basic connection test, try to create soup with a test URL
             try:
-                loop.run_until_complete(source_instance.create_soup(source_info["test_url"]))
+                asyncio.run(source_instance.create_soup(source_info["test_url"]))
                 click.secho(f"  ✔ {source_name}: Connection successful", fg="green", bold=True)
             except Exception as inner_e:
                 click.secho(f"  ✖ {source_name}: Error - {inner_e}", fg="red", bold=True)

--- a/salmon/common/__init__.py
+++ b/salmon/common/__init__.py
@@ -52,11 +52,9 @@ class Prompt:
             if not self.is_windows:
                 try:
                     loop = asyncio.get_running_loop()
-                    loop.add_reader(sys.stdin, self.got_input)
-                except RuntimeError:
-                    # Fallback if no running loop
-                    loop = asyncio.get_event_loop()
-                    loop.add_reader(sys.stdin, self.got_input)
+                except RuntimeError as exc:
+                    raise RuntimeError("Prompt must be called from a running event loop.") from exc
+                loop.add_reader(sys.stdin, self.got_input)
             else:
                 self.reader_task = asyncio.create_task(self._windows_input_reader())
             self.reader_added = True

--- a/salmon/images/base.py
+++ b/salmon/images/base.py
@@ -1,10 +1,8 @@
-import asyncio
 import contextlib
 import mimetypes
 import os
 
 mimetypes.init()
-loop = asyncio.get_event_loop()
 
 
 class BaseImageUploader:

--- a/salmon/images/emp.py
+++ b/salmon/images/emp.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import mimetypes
 import os
@@ -12,7 +11,6 @@ from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
 
 mimetypes.init()
-loop = asyncio.get_event_loop()
 
 HEADERS = {
     "User-Agent": choice(UAGENTS),

--- a/salmon/search/__init__.py
+++ b/salmon/search/__init__.py
@@ -36,8 +36,6 @@ SEARCHSOURCES = {
     "Deezer": deezer,
 }
 
-loop = asyncio.get_event_loop()
-
 
 @commandgroup.command()
 @click.argument("searchstr", nargs=-1, required=True)
@@ -97,7 +95,7 @@ def run_metasearch(
         for search in searchstrs
         for s in sources.values()
     ]
-    task_responses = loop.run_until_complete(asyncio.gather(*tasks))
+    task_responses = asyncio.run(asyncio.gather(*tasks))
     for source, result in [r or (None, None) for r in task_responses]:
         if result:
             if filter:

--- a/salmon/search/musicbrainz.py
+++ b/salmon/search/musicbrainz.py
@@ -7,12 +7,11 @@ from salmon.errors import ScrapeError
 from salmon.search.base import IdentData, SearchMixin
 from salmon.sources import MusicBrainzBase
 
-loop = asyncio.get_event_loop()
-
 
 class Searcher(MusicBrainzBase, SearchMixin):
     async def search_releases(self, searchstr, limit):
         releases = {}
+        loop = asyncio.get_running_loop()
         soup = await loop.run_in_executor(None, musicbrainzngs.search_releases, searchstr, 10)
         for rls in soup["release-list"]:
             try:

--- a/salmon/sources/base.py
+++ b/salmon/sources/base.py
@@ -16,8 +16,6 @@ HEADERS = {"User-Agent": choice(UAGENTS)}
 
 IdentData = namedtuple("IdentData", ["artist", "album", "year", "track_count", "source"])
 
-loop = asyncio.get_event_loop()
-
 
 class BaseScraper:
     url = NotImplementedError
@@ -47,6 +45,7 @@ class BaseScraper:
         Run an asynchronius GET request to a JSON API maintained by
         a metadata source.
         """
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: self.get_json_sync(url, params, headers))
 
     def get_json_sync(self, url, params=None, headers=None):
@@ -70,6 +69,7 @@ class BaseScraper:
         object containing the scraped HTML.
         """
         params = params or {}
+        loop = asyncio.get_running_loop()
         r = await loop.run_in_executor(
             None,
             lambda: httpx.get(

--- a/salmon/sources/deezer.py
+++ b/salmon/sources/deezer.py
@@ -10,8 +10,6 @@ from salmon.constants import UAGENTS
 from salmon.errors import ScrapeError
 from salmon.sources.base import BaseScraper
 
-loop = asyncio.get_event_loop()
-
 HEADERS = {
     "User-Agent": choice(UAGENTS),
     "Content-Language": "en-US",
@@ -86,7 +84,11 @@ class DeezerBase(BaseScraper):
         """Deezer puts some things in an api that isn't public facing.
         Like track information and album art before a release is available.
         """
-        track_data = await loop.run_in_executor(None, lambda: self.sesh.get(self.site_url + url, params=(params or {})))
+        loop = asyncio.get_running_loop()
+        track_data = await loop.run_in_executor(
+            None,
+            lambda: self.sesh.get(self.site_url + url, params=(params or {})),
+        )
         r = re.search(
             r"window.__DZR_APP_STATE__ = ({.*?}})</script>",
             track_data.text.replace("\n", ""),

--- a/salmon/tagger/__init__.py
+++ b/salmon/tagger/__init__.py
@@ -23,8 +23,6 @@ from salmon.tagger.review import review_metadata
 from salmon.tagger.sources import run_metadata
 from salmon.tagger.tags import check_tags, gather_tags, standardize_tags
 
-loop = asyncio.get_event_loop()
-
 
 def validate_source(ctx, param, value):
     try:
@@ -99,7 +97,7 @@ def tag(path, source, encoding, overwrite, auto_rename):
 def meta(url):
     """Scrape metadata from release link"""
     try:
-        metadata = loop.run_until_complete(run_metadata(url))
+        metadata = asyncio.run(run_metadata(url))
         for key in ["encoding", "media", "encoding_vbr", "source"]:
             del metadata[key]
         click.echo()

--- a/salmon/tagger/metadata.py
+++ b/salmon/tagger/metadata.py
@@ -12,8 +12,6 @@ from salmon.tagger.combine import combine_metadatas
 from salmon.tagger.sources import METASOURCES
 from salmon.tagger.sources.base import generate_artists
 
-loop = asyncio.get_event_loop()
-
 
 def get_metadata(path, tags, rls_data=None):
     """
@@ -149,7 +147,7 @@ def _select_choice(choices, rls_data):
                 return meta, source_url
             continue
 
-        metadatas = loop.run_until_complete(asyncio.gather(*tasks))
+        metadatas = asyncio.run(asyncio.gather(*tasks))
         meta = combine_metadatas(
             *((s, m) for s, m in zip(sources, metadatas, strict=False) if m), base=rls_data, source_url=source_url
         )

--- a/salmon/tagger/sources/__init__.py
+++ b/salmon/tagger/sources/__init__.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import click
 
 from salmon.errors import ScrapeError
@@ -26,8 +24,6 @@ METASOURCES = {
     "Tidal": tidal,
     "Bandcamp": bandcamp,  # Must be last due to the catch-all nature of its URLs.
 }
-
-loop = asyncio.get_event_loop()
 
 
 async def run_metadata(url, sources=None, return_source_name=False):

--- a/salmon/trackers/ops.py
+++ b/salmon/trackers/ops.py
@@ -9,8 +9,6 @@ from salmon.errors import (
 )
 from salmon.trackers.base import BaseGazelleApi
 
-loop = asyncio.get_event_loop()
-
 
 class OpsApi(BaseGazelleApi):
     def __init__(self):
@@ -78,7 +76,7 @@ class OpsApi(BaseGazelleApi):
             "extra": comment,
             "submit": True,
         }
-        r = await loop.run_in_executor(
+        r = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self.session.post(url, params=params, data=data, headers=self.headers),
         )

--- a/salmon/uploader/__init__.py
+++ b/salmon/uploader/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import platform
 import re
@@ -70,8 +69,6 @@ from salmon.uploader.upload import (
     concat_track_data,
     prepare_and_upload,
 )
-
-loop = asyncio.get_event_loop()
 
 
 @commandgroup.command()

--- a/salmon/uploader/preassumptions.py
+++ b/salmon/uploader/preassumptions.py
@@ -6,8 +6,6 @@ import click
 from salmon import cfg
 from salmon.errors import RequestError, UploadError
 
-loop = asyncio.get_event_loop()
-
 
 def print_preassumptions(gazelle_site, path, group_id, source, lossy, spectrals, encoding, spectrals_after):
     """Print what all the passed CLI options will do."""
@@ -56,7 +54,7 @@ def print_group_info(gazelle_site, group_id, source):
     Also print all the torrents that are in that group.
     """
     try:
-        group = loop.run_until_complete(gazelle_site.torrentgroup(group_id))
+        group = asyncio.run(gazelle_site.torrentgroup(group_id))
     except RequestError as err:
         raise UploadError("Could not get information about torrent group from RED.") from err
 

--- a/salmon/uploader/request_checker.py
+++ b/salmon/uploader/request_checker.py
@@ -8,8 +8,6 @@ import rich
 from salmon import cfg
 from salmon.errors import RequestError
 
-loop = asyncio.get_event_loop()
-
 
 def check_requests(gazelle_site, searchstrs):
     """
@@ -31,12 +29,10 @@ def get_request_results(gazelle_site, searchstrs):
     "Get the request results from gazelle site"
     results = []
     for searchstr in searchstrs:
-        for req in loop.run_until_complete(
-            gazelle_site.request("requests", search=searchstr)  # ,order='bounty')
-        )["results"]:
+        for req in asyncio.run(gazelle_site.request("requests", search=searchstr))["results"]:
             if req not in results:
                 results.append(req)
-    return [item for item in results if item["categoryName"] > 'Music']
+    return [item for item in results if item["categoryName"] > "Music"]
 
 
 def print_request_results(gazelle_site, results, searchstr):
@@ -147,7 +143,7 @@ def _prompt_for_request_id(gazelle_site, results):
 def _confirm_request_id(gazelle_site, request_id):
     """Have the user decide whether or not they want to fill request"""
     try:
-        req = loop.run_until_complete(gazelle_site.request("request", id=request_id))
+        req = asyncio.run(gazelle_site.request("request", id=request_id))
         req["artist"] = ""
         if len(req["musicInfo"]["artists"]) > 3:
             req["artist"] = "Various Artists"

--- a/salmon/uploader/spectrals.py
+++ b/salmon/uploader/spectrals.py
@@ -25,7 +25,6 @@ from salmon.errors import (
 from salmon.images import upload_spectrals as upload_spectral_imgs
 from salmon.web import create_app_async, spectrals
 
-loop = asyncio.get_event_loop()
 THREADS = [None] * cfg.upload.simultaneous_threads
 
 
@@ -243,7 +242,7 @@ def calculate_zoom_startpoint(track_data):
 def view_spectrals(spectrals_path, all_spectral_ids):
     """Open the generated spectrals in an image viewer."""
     if not cfg.upload.native_spectrals_viewer:
-        loop.run_until_complete(_open_specs_in_web_server(spectrals_path, all_spectral_ids))
+        asyncio.run(_open_specs_in_web_server(spectrals_path, all_spectral_ids))
     elif platform.system() == "Darwin":
         _open_specs_in_preview(spectrals_path)
     elif platform.system() == "Windows":
@@ -435,7 +434,7 @@ def report_lossy_master(
     """
 
     comment = _add_spectral_links_to_lossy_comment(comment, source_url, spectral_urls, spectral_ids)
-    loop.run_until_complete(gazelle_site.report_lossy_master(torrent_id, comment, source))
+    asyncio.run(gazelle_site.report_lossy_master(torrent_id, comment, source))
     click.secho("\nReported upload for Lossy Master/WEB Approval Request.", fg="cyan")
 
 
@@ -509,7 +508,7 @@ def post_upload_spectral_check(
 
     if spectral_urls:
         spectrals_bbcode = make_spectral_bbcode(spectral_ids, spectral_urls)
-        loop.run_until_complete(gazelle_site.append_to_torrent_description(torrent_id, spectrals_bbcode))
+        asyncio.run(gazelle_site.append_to_torrent_description(torrent_id, spectrals_bbcode))
 
     if lossy_master:
         report_lossy_master(

--- a/salmon/uploader/upload.py
+++ b/salmon/uploader/upload.py
@@ -15,8 +15,6 @@ from salmon.uploader.spectrals import (
     make_spectral_bbcode,
 )
 
-loop = asyncio.get_event_loop()
-
 
 def prepare_and_upload(
     gazelle_site,
@@ -69,7 +67,7 @@ def prepare_and_upload(
 
     click.secho("Uploading torrent...", fg="yellow")
     try:
-        torrent_id, group_id = loop.run_until_complete(gazelle_site.upload(data, files))
+        torrent_id, group_id = asyncio.run(gazelle_site.upload(data, files))
         return torrent_id, group_id, torrent_path, torrent_content
     except RequestError as e:
         click.secho(str(e), fg="red", bold=True)


### PR DESCRIPTION
# Fix import-time asyncio loop usage for Python 3.14 compatibility

Closes #238

## Summary
- Remove module-level asyncio.get_event_loop() usage across the codebase.
- Move loop access into async functions via asyncio.get_running_loop().
- Use asyncio.run(...) in sync CLI entrypoints to preserve blocking behavior.
### Why
Python 3.14 no longer creates a default event loop on import, so import-time get_event_loop() raises RuntimeError. This change defers loop access to runtime and aligns with modern asyncio best practices, preventing crashes while keeping CLI behavior the same.

### Testing
- Ran `uv run --python 3.14 salmon` and it no longer throws
- Also ran `uv run --python 3.13 salmon` and it doesn't have any issues, so seems backwards compatible