### PR TITLE
Add pyright type checking and fix version management in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Ensures we get all history for tag retrieval and pushing
-          token: ${{ secrets.BUMP_VERSION_TOKEN_ACTION }} 
+          fetch-depth: 0 # Ensures we get all history for tag retrieval and pushing
+          token: ${{ secrets.BUMP_VERSION_TOKEN_ACTION }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -82,7 +82,7 @@ jobs:
         env:
           RELEASE_NOTES: ${{ github.event.release.body }}
 
-      - name: Update version.py (only on release)
+      - name: Update version files
         if: github.event_name == 'release' && env.UPDATE_VERSION == 'true'
         run: |
           TIMESTAMP=$(date +"%Y-%m-%d")
@@ -110,6 +110,9 @@ jobs:
 
           # Update version in pyproject.toml
           sed -i "s/^version = \".*\"/version = \"${{ env.VERSION }}\"/" "$PYPROJECT_FILE"
+
+          # Regenerate uv.lock to update the package version
+          uv lock
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
 
@@ -121,9 +124,14 @@ jobs:
           git checkout master  # Ensure we're on master branch
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/version.py pyproject.toml
+          git add data/version.py pyproject.toml uv.lock
           git commit -m "Update version.py/pyproject.toml to ${{ env.VERSION }} with changelog"
           git push origin master
+
+      - name: Move tag to version bump commit and push
+        run: |
+          git tag -f ${{ env.VERSION }}
+          git push origin "refs/tags/${{ env.VERSION }}" --force
 
       - name: Debug VERSION and UPDATE_VERSION
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,17 +7,32 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  ruff:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
+        uses: actions/checkout@v6
 
       - name: Run Ruff
-        uses: astral-sh/ruff-action@v3.2.2
+        uses: astral-sh/ruff-action@v3
+
+  pyright:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync && uv pip install basedpyright
+
+      - name: Run Pyright Type Check
+        run: uv run basedpyright


### PR DESCRIPTION
- Add pyright type checking job to lint workflow
- Fix uv.lock not being regenerated when version is updated
- Move git tag to version bump commit after push to ensure tag points to correct commit
- Add GitHub Actions ecosystem to dependabot for automated workflow updates