### PR TITLE
Fix bugs and add smoked-salmon upload footer to descriptions

### DIFF
--- a/salmon/checks/mqa.py
+++ b/salmon/checks/mqa.py
@@ -50,7 +50,7 @@ def _decode_first_second(path: str) -> NDArray[np.int32]:
         if sample_rate is None:
             raise ValueError("Cannot determine sample rate")
 
-        resampler = av.audio.resampler.AudioResampler(format="s32", layout="stereo")
+        resampler = av.audio.resampler.AudioResampler(format="s32p", layout="stereo")
         target_samples = sample_rate  # 1 second
         collected: list[NDArray[np.int32]] = []
         total = 0
@@ -128,8 +128,8 @@ def _check_mqa_sync(path: str) -> bool:
     """
     try:
         samples = _decode_first_second(path)
-    except Exception:
-        click.secho(f"Failed to decode file: {path}", fg="red")
+    except Exception as e:
+        click.secho(f"Failed to decode file: {path}, error: {e}", fg="red")
         return False
 
     return _check_mqa_syncword(samples[:, 0], samples[:, 1])

--- a/salmon/converter/downconverting.py
+++ b/salmon/converter/downconverting.py
@@ -10,6 +10,7 @@ import msgspec
 
 from salmon.common.files import process_files
 from salmon.errors import InvalidSampleRate
+from salmon.release_notification import get_version
 from salmon.tagger.audio_info import gather_audio_info
 
 BitDepth = Literal[16, 24]
@@ -163,7 +164,6 @@ async def _convert_audio_files(
 
     async def _convert_one(file: str, idx: int) -> None:
         item = items[idx]
-        click.secho(f"Converting: {item.dst}", fg="cyan")
         Path(item.dst).parent.mkdir(parents=True, exist_ok=True)
 
         command = [
@@ -243,4 +243,6 @@ def generate_conversion_description(url: str, sample_rate: int | None, bit_depth
         f"Encode Specifics: {bit_depth} bit {sample_rate / 1000:.01f} kHz\n"
         f"[b]Source:[/b] {url}\n"
         f"[b]Transcode process:[/b] [code]{sox_cmd}[/code]\n"
+        f"[hr]Uploaded with [url=https://github.com/smokin-salmon/smoked-salmon]"
+        f"[b]smoked-salmon[/b] v{get_version()}[/url]"
     )

--- a/salmon/sources/__init__.py
+++ b/salmon/sources/__init__.py
@@ -27,7 +27,7 @@ SOURCE_ICONS = {
     "Bandcamp": "https://ptpimg.me/91oo89.png",
     "Beatport": "https://ptpimg.me/5hwjpv.png",
     "Deezer": "https://ptpimg.me/m265v2.png",
-    "Discogs": "https://ptpimg.me/13y32k.png",
+    "Discogs": "https://ptpimg.me/mt4ql3.png",
     "iTunes": "https://ptpimg.me/0z2x90.png",
     "Junodownload": "https://ptpimg.me/u1rpx9.png",
     "MusicBrainz": "https://ptpimg.me/56plwd.png",

--- a/salmon/sources/musicbrainz.py
+++ b/salmon/sources/musicbrainz.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any
 
+import anyio.to_thread
 import musicbrainzngs
 
 from .base import BaseScraper
@@ -34,16 +35,19 @@ class MusicBrainzBase(BaseScraper):
         if not match:
             raise ValueError("Invalid MusicBrainz URL.")
         rls_id = match[1]
-        return musicbrainzngs.get_release_by_id(
-            rls_id,
-            [
-                "artists",
-                "labels",
-                "recordings",
-                "release-groups",
-                "media",
-                "artist-credits",
-                "artist-rels",
-                "recording-level-rels",
-            ],
+        return (
+            await anyio.to_thread.run_sync(
+                musicbrainzngs.get_release_by_id,
+                rls_id,
+                [
+                    "artists",
+                    "labels",
+                    "recordings",
+                    "release-groups",
+                    "media",
+                    "artist-credits",
+                    "artist-rels",
+                    "recording-level-rels",
+                ],
+            )
         )["release"]

--- a/salmon/trackers/base.py
+++ b/salmon/trackers/base.py
@@ -54,15 +54,25 @@ def _compose_form_data(files: FormData, data: dict[str, Any]) -> FormData:
     for key, value in data.items():
         if isinstance(value, list):
             for item in value:
-                # Convert bool to string for FormData compatibility
-                if isinstance(item, bool):
-                    item = str(item).lower()
-                files.add_field(key, item)
+                # aiohttp FormData only accepts str/bytes/IO types, not int/bool
+                if item is True:
+                    files.add_field(key, "on")
+                elif item is False or item is None:
+                    continue
+                elif isinstance(item, int):
+                    files.add_field(key, str(item))
+                else:
+                    files.add_field(key, item)
         else:
-            # Convert bool to string for FormData compatibility
-            if isinstance(value, bool):
-                value = str(value).lower()
-            files.add_field(key, value)
+            # aiohttp FormData only accepts str/bytes/IO types, not int/bool
+            if value is True:
+                files.add_field(key, "on")
+            elif value is False or value is None:
+                continue
+            elif isinstance(value, int):
+                files.add_field(key, str(value))
+            else:
+                files.add_field(key, value)
     return files
 
 

--- a/salmon/uploader/spectrals.py
+++ b/salmon/uploader/spectrals.py
@@ -616,7 +616,7 @@ async def post_upload_spectral_check(
     source: str | None,
     source_url: str | None,
     format: str = "FLAC",
-) -> tuple[bool | None, str | None, dict[int, list[str]] | None, dict[int, str] | None]:
+) -> tuple[bool, str | None, dict[int, list[str]] | None, dict[int, str] | None]:
     """Generate and add spectrals after upload.
 
     As this is post upload, we have time to ask if this is a lossy master.
@@ -638,7 +638,7 @@ async def post_upload_spectral_check(
         path, track_data, None, spectral_ids, force_prompt_lossy_master=True, format=format
     )
     if not lossy_master and not spectral_ids:
-        return None, None, None, None
+        return False, None, None, None
 
     lossy_comment = None
     if lossy_master:
@@ -664,4 +664,4 @@ async def post_upload_spectral_check(
             lossy_comment,
             source_url,
         )
-    return lossy_master, lossy_comment, spectral_urls, spectral_ids
+    return bool(lossy_master), lossy_comment, spectral_urls, spectral_ids


### PR DESCRIPTION
- Add "Uploaded with smoked-salmon" footer to torrent, transcode and downconvert descriptions
- Fix MQA audio resampler format from s32 to s32p to correct sample interleaving in MQA detection
- Unify mqa_test() behavior to raise click.Abort for both file and directory paths; directories previously returned bool silently
- Fix aiohttp FormData compatibility by correctly converting bool/int/None values; True maps to "on", False/None are skipped entirely
- Fix spectrals return type consistency by replacing None early return with False in post_upload_spectral_check()
- Fix check_existing_group() call to remove extraneous metadata argument
- Fix check_tags() call with await since the function is async
- Wrap blocking musicbrainzngs call in anyio.to_thread.run_sync() to avoid blocking the event loop
- Replace anyio.open_process with asyncio subprocesses in transcoding to correct pipe coordination and process lifecycle management
- Update broken Discogs icon URL
- Use bit-depth-specific icons in generate_t_description() instead of a single icon for all precisions
- Extract _extract_version() helper to deduplicate regex logic and expose public get_version() API in release_notification module
- Remove unused scene parameter from _handle_bad_extension()

Fixes https://github.com/smokin-salmon/smoked-salmon/issues/282