### PR TITLE
Migrate version file to TOML format

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,9 @@ jobs:
           fetch-depth: 0 # Ensures we get all history for tag retrieval and pushing
           token: ${{ secrets.BUMP_VERSION_TOKEN_ACTION }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -85,28 +88,10 @@ jobs:
       - name: Update version files
         if: github.event_name == 'release' && env.UPDATE_VERSION == 'true'
         run: |
-          TIMESTAMP=$(date +"%Y-%m-%d")
-          VERSION_FILE="data/version.py"
           PYPROJECT_FILE="pyproject.toml"
 
-          # Create version.py if it doesn't exist
-          if [ ! -f "$VERSION_FILE" ]; then
-            echo "__version__ = \"0.0.0\"" > "$VERSION_FILE"
-            echo "" >> "$VERSION_FILE"
-          fi
-
-          # Prepend new release info
-          TEMP_FILE=$(mktemp)
-          echo "__version__ = \"${{ env.VERSION }}\"" > "$TEMP_FILE"
-          echo "" >> "$TEMP_FILE"
-          echo "\"\"\"" >> "$TEMP_FILE"
-          echo "Changelog for version ${{ env.VERSION }} ($TIMESTAMP):" >> "$TEMP_FILE"
-          echo "" >> "$TEMP_FILE"
-          echo "$RELEASE_NOTES" >> "$TEMP_FILE"
-          echo "\"\"\"" >> "$TEMP_FILE"
-          echo "" >> "$TEMP_FILE"
-          cat "$VERSION_FILE" >> "$TEMP_FILE"
-          mv "$TEMP_FILE" "$VERSION_FILE"
+          # Prepend new changelog entry and update current version
+          uv run --with tomlkit python -c $'import os, tomlkit\n\nfrom datetime import date\n\nversion = os.environ["VERSION"]\nrelease_date = date.today().strftime("%Y-%m-%d")\nnotes = os.environ["RELEASE_NOTES"]\npath = "data/version.toml"\n\nwith open(path, "r", encoding="utf-8") as f:\n    data = tomlkit.load(f)\n\ndata["current"] = version\n\nentry = tomlkit.table()\nentry.add("version", version)\nentry.add("date", release_date)\nentry.add("notes", tomlkit.string(notes, multiline=True))\nentry.add(tomlkit.nl())\n\ndata["changelog"].insert(0, entry)\n\nwith open(path, "w", encoding="utf-8") as f:\n    tomlkit.dump(data, f)\n'
 
           # Update version in pyproject.toml
           sed -i "s/^version = \".*\"/version = \"${{ env.VERSION }}\"/" "$PYPROJECT_FILE"
@@ -124,8 +109,8 @@ jobs:
           git checkout master  # Ensure we're on master branch
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/version.py pyproject.toml uv.lock
-          git commit -m "Update version.py/pyproject.toml to ${{ env.VERSION }} with changelog"
+          git add data/version.toml pyproject.toml uv.lock
+          git commit -m "Update version.toml/pyproject.toml to ${{ env.VERSION }} with changelog"
           git push origin master
 
       - name: Move tag to version bump commit and push

--- a/data/version.toml
+++ b/data/version.toml
@@ -1,8 +1,9 @@
-__version__ = "0.9.7.4"
+current = "0.9.7.4"
 
-"""
-Changelog for version 0.9.7.4 (2025-09-26):
-
+[[changelog]]
+version = "0.9.7.4"
+date = "2025-09-26"
+notes = """
 ## What's Changed
 * Add support for Python 3.12+ and use dependabot for dependency updates by @KyokoMiki in https://github.com/smokin-salmon/smoked-salmon/pull/172
 * Fix ruTorrent connection URL parsing and add connection test by @KyokoMiki in https://github.com/smokin-salmon/smoked-salmon/pull/173
@@ -19,11 +20,10 @@ Changelog for version 0.9.7.4 (2025-09-26):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.7.3...0.9.7.4
 """
 
-__version__ = "0.9.7.3"
-
-"""
-Changelog for version 0.9.7.3 (2025-09-04):
-
+[[changelog]]
+version = "0.9.7.3"
+date = "2025-09-04"
+notes = """
 ### ⚙ New Options
 
 #### Default Editor Configuration
@@ -85,11 +85,10 @@ Added **metadata sources and seedbox connection testing**:
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.7.2...0.9.7.3
 """
 
-__version__ = "0.9.7.2"
-
-"""
-Changelog for version 0.9.7.2 (2025-08-23):
-
+[[changelog]]
+version = "0.9.7.2"
+date = "2025-08-23"
+notes = """
 ## What's Changed
 * Add illegal folder detection and various fixes by @KyokoMiki in https://github.com/smokin-salmon/smoked-salmon/pull/161
 
@@ -97,11 +96,10 @@ Changelog for version 0.9.7.2 (2025-08-23):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.7.1...0.9.7.2
 """
 
-__version__ = "0.9.7.1"
-
-"""
-Changelog for version 0.9.7.1 (2025-08-21):
-
+[[changelog]]
+version = "0.9.7.1"
+date = "2025-08-21"
+notes = """
 ## What's Changed
 * Multiple bug fixes and improvements by @KyokoMiki in https://github.com/smokin-salmon/smoked-salmon/pull/155
 * Resolve Linux input issues by @KyokoMiki in https://github.com/smokin-salmon/smoked-salmon/pull/157
@@ -112,11 +110,10 @@ Changelog for version 0.9.7.1 (2025-08-21):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.7...0.9.7.1
 """
 
-__version__ = "0.9.7"
-
-"""
-Changelog for version 0.9.7 (2025-08-20):
-
+[[changelog]]
+version = "0.9.7"
+date = "2025-08-20"
+notes = """
 ## ⚠️ Breaking Change: Torrent Client Injection
 
 This release introduces **breaking changes** to the torrent client integration system.
@@ -202,11 +199,10 @@ auto_compress_cover = true  # Set to true to enable
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.6.1...0.9.7
 """
 
-__version__ = "0.9.6.1"
-
-"""
-Changelog for version 0.9.6.1 (2025-08-18):
-
+[[changelog]]
+version = "0.9.6.1"
+date = "2025-08-18"
+notes = """
 This version fixes the issue on Windows platform where sometimes input would not be confirmed immediately and required multiple confirmations.
 
 Oxipng and cambia no longer need to be installed as dependencies. All external dependencies required by the current program can now be installed directly using the system package manager. 
@@ -224,11 +220,10 @@ Oxipng and cambia no longer need to be installed as dependencies. All external d
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.6...0.9.6.1
 """
 
-__version__ = "0.9.6"
-
-"""
-Changelog for version 0.9.6 (2025-07-21):
-
+[[changelog]]
+version = "0.9.6"
+date = "2025-07-21"
+notes = """
 As of this version, smoked-salmon should now be able to run natively on Windows. This release features a refactored transcoding and downconverting module based on m3ercat, and other parts that were incompatible with Windows have also been refactored.
 
 ## What's Changed
@@ -249,11 +244,10 @@ As of this version, smoked-salmon should now be able to run natively on Windows.
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.5.1...0.9.6
 """
 
-__version__ = "0.9.5.1"
-
-"""
-Changelog for version 0.9.5.1 (2025-06-15):
-
+[[changelog]]
+version = "0.9.5.1"
+date = "2025-06-15"
+notes = """
 Fixed the error that occurred during torrent creation caused by switching from dottorrent to torf.
 
 ## What's Changed
@@ -267,11 +261,10 @@ Fixed the error that occurred during torrent creation caused by switching from d
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.5...0.9.5.1
 """
 
-__version__ = "0.9.5"
-
-"""
-Changelog for version 0.9.5 (2025-06-14):
-
+[[changelog]]
+version = "0.9.5"
+date = "2025-06-14"
+notes = """
 ## ⚠️ Breaking Change: Configuration File Format
 
 This release introduces a **major breaking change**: we are transitioning away from the legacy `config.py` configuration file.
@@ -303,11 +296,10 @@ We understand this requires extra effort and appreciate your patience as we make
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.9...0.9.5
 """
 
-__version__ = "0.9.4.9"
-
-"""
-Changelog for version 0.9.4.9 (2025-06-02):
-
+[[changelog]]
+version = "0.9.4.9"
+date = "2025-06-02"
+notes = """
 ## What's Changed
 * Fix spectrals folder rename when using TMP_DIR by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/101
 
@@ -315,11 +307,10 @@ Changelog for version 0.9.4.9 (2025-06-02):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.8...0.9.4.9
 """
 
-__version__ = "0.9.4.8"
-
-"""
-Changelog for version 0.9.4.8 (2025-06-02):
-
+[[changelog]]
+version = "0.9.4.8"
+date = "2025-06-02"
+notes = """
 Please report if you encounter crashes or strange behavior when using `TMP_DIR`. All known issues related to that seem to be fixed for now.
 
 ## What's Changed
@@ -333,11 +324,10 @@ Please report if you encounter crashes or strange behavior when using `TMP_DIR`.
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.7...0.9.4.8
 """
 
-__version__ = "0.9.4.7"
-
-"""
-Changelog for version 0.9.4.7 (2025-06-01):
-
+[[changelog]]
+version = "0.9.4.7"
+date = "2025-06-01"
+notes = """
 New options:
 `TMP_DIR`: spectrals will be generated in this folder, instead of the album folder. Leave empty to keep the old behavior.
 `CLEAN_TMP_DIR`: cleanup the temp folder on each startup. Careful though, this option removes all files from the temp folder, so make sure it's only used by smoked salmon. This option has no effect if `TMP_DIR` is undefined.
@@ -351,11 +341,10 @@ New options:
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.6...0.9.4.7
 """
 
-__version__ = "0.9.4.6"
-
-"""
-Changelog for version 0.9.4.6 (2025-05-28):
-
+[[changelog]]
+version = "0.9.4.6"
+date = "2025-05-28"
+notes = """
 ## What's Changed
 * Fix tag crash due to rename_files refactoring by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/91
 
@@ -363,21 +352,19 @@ Changelog for version 0.9.4.6 (2025-05-28):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.5...0.9.4.6
 """
 
-__version__ = "0.9.4.5"
-
-"""
-Changelog for version 0.9.4.5 (2025-05-28):
-
+[[changelog]]
+version = "0.9.4.5"
+date = "2025-05-28"
+notes = """
 Fix docker build
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.4...0.9.4.5
 """
 
-__version__ = "0.9.4.4"
-
-"""
-Changelog for version 0.9.4.4 (2025-05-28):
-
+[[changelog]]
+version = "0.9.4.4"
+date = "2025-05-28"
+notes = """
 CD uploads will now automatically check for logs (score, edited logs, matching CRC with files).
 You can pass `--skip-log-check` to bypass that check.
 
@@ -388,11 +375,10 @@ You can pass `--skip-log-check` to bypass that check.
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.3...0.9.4.4
 """
 
-__version__ = "0.9.4.3"
-
-"""
-Changelog for version 0.9.4.3 (2025-05-28):
-
+[[changelog]]
+version = "0.9.4.3"
+date = "2025-05-28"
+notes = """
 Added two new image hosters: oeimg and ptscreens. You will need to register on their site, and provide your API Key in your `config.py` file (`OEIMG_KEY` and `PTSCREENS_KEY`).
 Also removed imgur as an option, due to its autoremoval policy making it unsuitable for this use case.
 
@@ -403,11 +389,10 @@ Also removed imgur as an option, due to its autoremoval policy making it unsuita
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.2...0.9.4.3
 """
 
-__version__ = "0.9.4.2"
-
-"""
-Changelog for version 0.9.4.2 (2025-05-27):
-
+[[changelog]]
+version = "0.9.4.2"
+date = "2025-05-27"
+notes = """
 ## What's Changed
 * Fix Juno feat artists parsing by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/86
 * Fix uploading tracks with no album tags (crash)
@@ -416,11 +401,10 @@ Changelog for version 0.9.4.2 (2025-05-27):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4.1...0.9.4.2
 """
 
-__version__ = "0.9.4.1"
-
-"""
-Changelog for version 0.9.4.1 (2025-05-27):
-
+[[changelog]]
+version = "0.9.4.1"
+date = "2025-05-27"
+notes = """
 ## What's Changed
 * Use beatport track_id instead of label_track_identifier by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/85
 
@@ -428,11 +412,10 @@ Changelog for version 0.9.4.1 (2025-05-27):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.4...0.9.4.1
 """
 
-__version__ = "0.9.4"
-
-"""
-Changelog for version 0.9.4 (2025-05-27):
-
+[[changelog]]
+version = "0.9.4"
+date = "2025-05-27"
+notes = """
 Big news: beatport scraping is back! Please report any strangeness (if possible with the associated link) that you may encounter.
 
 ## What's Changed
@@ -444,11 +427,10 @@ Big news: beatport scraping is back! Please report any strangeness (if possible 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.7...0.9.4
 """
 
-__version__ = "0.9.3.7"
-
-"""
-Changelog for version 0.9.3.7 (2025-05-12):
-
+[[changelog]]
+version = "0.9.3.7"
+date = "2025-05-12"
+notes = """
 ## What's Changed
 * Use only lame for transcoding by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/74
 * Allow using workdir with docker (-w) by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/75
@@ -457,24 +439,10 @@ Changelog for version 0.9.3.7 (2025-05-12):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.6.1...0.9.3.7
 """
 
-__version__ = "0.9.3.7"
-
-"""
-Changelog for version 0.9.3.7 (2025-05-12):
-
-## What's Changed
-* Use only lame for transcoding by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/74
-* Allow using workdir with docker (-w) by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/75
-* Fix strict python version (3.11) by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/76
-
-**Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.6.1...0.9.3.7
-"""
-
-__version__ = "0.9.3.6.1"
-
-"""
-Changelog for version 0.9.3.6.1 (2025-05-10):
-
+[[changelog]]
+version = "0.9.3.6.1"
+date = "2025-05-10"
+notes = """
 Technical fix for python 3.11
 
 ## What's Changed
@@ -484,11 +452,10 @@ Technical fix for python 3.11
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.6...0.9.3.6.1
 """
 
-__version__ = "0.9.3.6"
-
-"""
-Changelog for version 0.9.3.6 (2025-05-09):
-
+[[changelog]]
+version = "0.9.3.6"
+date = "2025-05-09"
+notes = """
 Transcoding should now work on docker, thanks to @milkers69 !
 
 ## What's Changed
@@ -503,11 +470,10 @@ Transcoding should now work on docker, thanks to @milkers69 !
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.5...0.9.3.6
 """
 
-__version__ = "0.9.3.5"
-
-"""
-Changelog for version 0.9.3.5 (2025-04-24):
-
+[[changelog]]
+version = "0.9.3.5"
+date = "2025-04-24"
+notes = """
 Big update from Audionut! The coolest part: you can now send torrents straight to qBittorrent using its API. No more messing with watched folders or adding them by hand.
 
 Check `config.py.txt` for the new `QBITTORRENT_XXX` settings. With that option, if you’re using Docker, you might not need to map the `.torrents` folder anymore, just use `/app/.torrents` inside the container: torrents will be generated there and injected into qbittorrent. Additional configuration, specific to docker, might be necessary to be able to call the `qbittorrent` API from smoked-salmon container.
@@ -521,11 +487,10 @@ Check `config.py.txt` for the new `QBITTORRENT_XXX` settings. With that option, 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.4...0.9.3.5
 """
 
-__version__ = "0.9.3.4"
-
-"""
-Changelog for version 0.9.3.4 (2025-04-17):
-
+[[changelog]]
+version = "0.9.3.4"
+date = "2025-04-17"
+notes = """
 ## What's Changed
 * Identify Self-Released label correctly when retrieved from base tags by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/57
 * Fix crash when folder already exists by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/58
@@ -534,11 +499,10 @@ Changelog for version 0.9.3.4 (2025-04-17):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.3...0.9.3.4
 """
 
-__version__ = "0.9.3.3"
-
-"""
-Changelog for version 0.9.3.3 (2025-04-16):
-
+[[changelog]]
+version = "0.9.3.3"
+date = "2025-04-16"
+notes = """
 We welcome @Audionut to the list of contributors 💯 
 He actually already contributed, unknowingly, a good part of the docker image build and the update changelog mechanism ! 💘 
 
@@ -552,11 +516,10 @@ He actually already contributed, unknowingly, a good part of the docker image bu
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.2...0.9.3.3
 """
 
-__version__ = "0.9.3.2"
-
-"""
-Changelog for version 0.9.3.2 (2025-04-16):
-
+[[changelog]]
+version = "0.9.3.2"
+date = "2025-04-16"
+notes = """
 ## What's Changed
 * Fix /app permission when running docker as non-root by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/53
 
@@ -564,11 +527,10 @@ Changelog for version 0.9.3.2 (2025-04-16):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3.1...0.9.3.2
 """
 
-__version__ = "0.9.3.1"
-
-"""
-Changelog for version 0.9.3.1 (2025-04-15):
-
+[[changelog]]
+version = "0.9.3.1"
+date = "2025-04-15"
+notes = """
 ## What's Changed
 * Fix crashes by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/52
   * Fix crash when uploading to an existing group
@@ -578,11 +540,10 @@ Changelog for version 0.9.3.1 (2025-04-15):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.3...0.9.3.1
 """
 
-__version__ = "0.9.3"
-
-"""
-Changelog for version 0.9.3 (2025-04-15):
-
+[[changelog]]
+version = "0.9.3"
+date = "2025-04-15"
+notes = """
 Hardlinks are now used by default when copying files (if source and destination are on the same volume), unless the `DISABLE_HARDLINKS` config is set to `True` (default: `False`).
 New `REMOVE_AUTO_DOWNLOADED_COVER_IMAGE` config option (default: `False`).
 
@@ -601,11 +562,10 @@ New `REMOVE_AUTO_DOWNLOADED_COVER_IMAGE` config option (default: `False`).
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.20...0.9.3
 """
 
-__version__ = "0.9.2.20"
-
-"""
-Changelog for version 0.9.2.20 (2025-04-11):
-
+[[changelog]]
+version = "0.9.2.20"
+date = "2025-04-11"
+notes = """
 ## What's Changed
 * Fix crash when pasting recent log url from RED by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/38
 * Improve metadata scraping by @redusys in https://github.com/smokin-salmon/smoked-salmon/pull/39
@@ -617,11 +577,10 @@ Changelog for version 0.9.2.20 (2025-04-11):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.19...0.9.2.20
 """
 
-__version__ = "0.9.2.19"
-
-"""
-Changelog for version 0.9.2.19 (2025-04-10):
-
+[[changelog]]
+version = "0.9.2.19"
+date = "2025-04-10"
+notes = """
 There is a new option available for use in config.py: `REMOVE_SOURCE_DIR ` (default value: `False`)
 When set to `True`, the source folder will be deleted after it has been copied to the target location.
 
@@ -643,11 +602,10 @@ When set to `True`, the source folder will be deleted after it has been copied t
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.18...0.9.2.19
 """
 
-__version__ = "0.9.2.18"
-
-"""
-Changelog for version 0.9.2.18 (2025-04-08):
-
+[[changelog]]
+version = "0.9.2.18"
+date = "2025-04-08"
+notes = """
 ## What's Changed
 * Update Juno Source Artist Selectors by @digerati-red in https://github.com/smokin-salmon/smoked-salmon/pull/29
 
@@ -657,11 +615,10 @@ Changelog for version 0.9.2.18 (2025-04-08):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.17...0.9.2.18
 """
 
-__version__ = "0.9.2.17"
-
-"""
-Changelog for version 0.9.2.17 (2025-04-07):
-
+[[changelog]]
+version = "0.9.2.17"
+date = "2025-04-07"
+notes = """
 ## What's Changed
 * Fix mp3 upload (fix crash)
 * Fix scene uploads: they should now work properly!
@@ -671,22 +628,20 @@ Changelog for version 0.9.2.17 (2025-04-07):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.16...0.9.2.17
 """
 
-__version__ = "0.9.2.16"
-
-"""
-Changelog for version 0.9.2.16 (2025-04-06):
-
+[[changelog]]
+version = "0.9.2.16"
+date = "2025-04-06"
+notes = """
 ## What's Changed
 * Remove leftover debug statement
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.15...0.9.2.16
 """
 
-__version__ = "0.9.2.15"
-
-"""
-Changelog for version 0.9.2.15 (2025-04-06):
-
+[[changelog]]
+version = "0.9.2.15"
+date = "2025-04-06"
+notes = """
 ## Metadata Parsing Improvements
 
 Numerous small changes were made to improve metadata parsing accuracy.  
@@ -717,11 +672,10 @@ If you encounter any strange metadata behavior, please share feedback — and if
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.14...0.9.2.15
 """
 
-__version__ = "0.9.2.14"
-
-"""
-Changelog for version 0.9.2.14 (2025-04-05):
-
+[[changelog]]
+version = "0.9.2.14"
+date = "2025-04-05"
+notes = """
 ## What's Changed
 * Fix request filling output for OPS (cosmetics only, requests were being filled correctly)
 * Fix salmon upconv for single files, fixes #20 
@@ -730,11 +684,10 @@ Changelog for version 0.9.2.14 (2025-04-05):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.13...0.9.2.14
 """
 
-__version__ = "0.9.2.13"
-
-"""
-Changelog for version 0.9.2.13 (2025-04-04):
-
+[[changelog]]
+version = "0.9.2.13"
+date = "2025-04-04"
+notes = """
 The file `config.py.txt` has been updated to include all possible configuration options along with their default values. If any options are unclear or insufficiently detailed on the wiki, feel free to open issues or submit PRs to enhance the documentation.
 
 ## What's Changed
@@ -745,41 +698,37 @@ The file `config.py.txt` has been updated to include all possible configuration 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.12...0.9.2.13
 """
 
-__version__ = "0.9.2.12"
-
-"""
-Changelog for version 0.9.2.12 (2025-04-04):
-
+[[changelog]]
+version = "0.9.2.12"
+date = "2025-04-04"
+notes = """
 Technical release - still testing github actions
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.11...0.9.2.12
 """
 
-__version__ = "0.9.2.11"
-
-"""
-Changelog for version 0.9.2.11 (2025-04-04):
-
+[[changelog]]
+version = "0.9.2.11"
+date = "2025-04-04"
+notes = """
 Technical release - Testing github actions
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.10...0.9.2.11
 """
 
-__version__ = "0.9.2.10"
-
-"""
-Changelog for version 0.9.2.10 (2025-04-04):
-
+[[changelog]]
+version = "0.9.2.10"
+date = "2025-04-04"
+notes = """
 Technical release - Nothing changed.
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.9...0.9.2.10
 """
 
-__version__ = "0.9.2.9"
-
-"""
-Changelog for version 0.9.2.9 (2025-04-04):
-
+[[changelog]]
+version = "0.9.2.9"
+date = "2025-04-04"
+notes = """
 ## What's Changed
 * Fix github action rights to bump versions
 
@@ -787,11 +736,10 @@ Changelog for version 0.9.2.9 (2025-04-04):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.8...0.9.2.9
 """
 
-__version__ = "0.9.2.7"
-
-"""
-Changelog for version 0.9.2.7 (2025-04-03):
-
+[[changelog]]
+version = "0.9.2.7"
+date = "2025-04-03"
+notes = """
 ## What's Changed
 * Fix crash when folder doesn't need to be renamed (shutil related crash)
 * Fix crash when exiting editor without saving during metadata edition
@@ -801,11 +749,10 @@ Changelog for version 0.9.2.7 (2025-04-03):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.6...0.9.2.7
 """
 
-__version__ = "0.9.2.6"
-
-"""
-Changelog for version 0.9.2.6 (2025-04-02):
-
+[[changelog]]
+version = "0.9.2.6"
+date = "2025-04-02"
+notes = """
 ## What's Changed
 * Improve Multi-Discs releases ! It should be working fine, feedback appreciated.
 * For post-upload lma checks, ask if this is a lma and which spectrals to upload (even if YES_ALL is active)
@@ -814,11 +761,10 @@ Changelog for version 0.9.2.6 (2025-04-02):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.5...0.9.2.6
 """
 
-__version__ = "0.9.2.5"
-
-"""
-Changelog for version 0.9.2.5 (2025-04-02):
-
+[[changelog]]
+version = "0.9.2.5"
+date = "2025-04-02"
+notes = """
 ## What's Changed
 * Fix spectrals upload in multi trackers scenario and post-upload spectrals check
 * Force lossy master prompt if checking spectrals post upload (upload is done, we have time)
@@ -827,22 +773,20 @@ Changelog for version 0.9.2.5 (2025-04-02):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.4...0.9.2.5
 """
 
-__version__ = "0.9.2.4"
-
-"""
-Changelog for version 0.9.2.4 (2025-04-01):
-
+[[changelog]]
+version = "0.9.2.4"
+date = "2025-04-01"
+notes = """
 ## What's Changed
 * Add `--skip-mqa` option to skip the MQA check during upload
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.3...0.9.2.4
 """
 
-__version__ = "0.9.2.3"
-
-"""
-Changelog for version 0.9.2.3 (2025-04-01):
-
+[[changelog]]
+version = "0.9.2.3"
+date = "2025-04-01"
+notes = """
 ## New dependency
 Oxipng is a modern replacement for OptiPNG, written in Rust and optimized for multi-core processors. It offers faster processing and better compression than OptiPNG. Smoked-salmon now utilizes Oxipng for PNG compression, achieving around a 30% reduction in file size, making it more efficient for image hosting.
 
@@ -862,22 +806,20 @@ Alternatively, you can still disable compression by setting `COMPRESS_SPECTRALS 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.2...0.9.2.3
 """
 
-__version__ = "0.9.2.2"
-
-"""
-Changelog for version 0.9.2.2 (2025-03-31):
-
+[[changelog]]
+version = "0.9.2.2"
+date = "2025-03-31"
+notes = """
 ## What's Changed
 * Fix special characters handling in github actions (like `this is a string` or `this`)
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2.1...0.9.2.2
 """
 
-__version__ = "0.9.2.1"
-
-"""
-Changelog for version 0.9.2.1 (2025-03-31):
-
+[[changelog]]
+version = "0.9.2.1"
+date = "2025-03-31"
+notes = """
 ##New config options
 * DEBUG_TRACKER_CONNECTION : Automatically set to True when using the  subcommand. It shouldn't be needed to override this option manually in your config.py
 * UPDATE_NOTIFICATION : when set to True (default value), will show a notice message when a new version is available on this repository
@@ -890,11 +832,10 @@ Changelog for version 0.9.2.1 (2025-03-31):
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.2...0.9.2.1
 """
 
-__version__ = "0.9.2"
-
-"""
-Changelog for version 0.9.2 (2025-03-31):
-
+[[changelog]]
+version = "0.9.2"
+date = "2025-03-31"
+notes = """
 First pre-release since creating this new home for smoked-salmon.
 
 ## What's Changed
@@ -910,4 +851,3 @@ First pre-release since creating this new home for smoked-salmon.
 
 **Full Changelog**: https://github.com/smokin-salmon/smoked-salmon/compare/0.9.1...0.9.2
 """
-

--- a/salmon/release_notification.py
+++ b/salmon/release_notification.py
@@ -1,113 +1,144 @@
-import re
 from os import path
 
 import asyncclick as click
+import msgspec
 import requests
+from packaging.version import Version
 
 from salmon import cfg
 
-LOCAL_VERSION_FILE = path.abspath(path.join(path.dirname(path.dirname(__file__)), "data", "version.py"))
-REMOTE_VERSION_URL = "https://raw.githubusercontent.com/smokin-salmon/smoked-salmon/refs/heads/master/data/version.py"
+LOCAL_VERSION_FILE = path.abspath(path.join(path.dirname(path.dirname(__file__)), "data", "version.toml"))
+REMOTE_VERSION_URL = "https://raw.githubusercontent.com/smokin-salmon/smoked-salmon/refs/heads/master/data/version.toml"
 
 
-def _extract_changelog(content, from_version, to_version):
-    """Extracts the changelog entries between the specified versions."""
-    pattern = rf'__version__\s*=\s*"{re.escape(to_version)}"\s*(.*?)__version__\s*=\s*"{re.escape(from_version)}"'
-    match = re.search(pattern, content, re.DOTALL)
-    return match.group(1).strip() if match else None
+class ChangelogEntry(msgspec.Struct, frozen=True):
+    version: str
+    notes: str
+    date: str
+
+    @property
+    def formatted(self) -> str:
+        """Formats the entry as a human-readable changelog block.
+
+        Returns:
+            A string with a header line followed by the stripped notes content.
+        """
+        return f"Changelog for version {self.version} ({self.date}):\n{self.notes.strip()}"
 
 
-def _extract_version(content: str) -> str | None:
-    """Extracts the version string from file content."""
-    match = re.search(r'__version__\s*=\s*"([^"]+)"', content)
-    return match.group(1) if match else None
+class VersionData(msgspec.Struct, frozen=True):
+    current: str
+    changelog: list[ChangelogEntry]
 
 
-def _parse_version(ver):
-    """Convert a version string into a tuple for comparison, handling pre-release versions."""
-    match = re.match(r"(\d+(?:\.\d+)*)-?([a-zA-Z]*)", ver)
-    if not match:
-        return (0,)
-    num_part = tuple(map(int, match.group(1).split(".")))
-    suffix = match.group(2)
+def _extract_changelog(data: VersionData, from_version: str, to_version: str) -> str | None:
+    """Extracts changelog entries between two versions.
 
-    # Assign a weight for pre-release tags (lower than final versions)
-    suffix_order = {"alpha": -3, "beta": -2, "rc": -1, "": 0}
+    Args:
+        data: Parsed version data containing the changelog list.
+        from_version: The lower bound version (exclusive).
+        to_version: The upper bound version (inclusive).
 
-    return num_part + (suffix_order.get(suffix, -4),)  # Default to lowest priority if unknown
+    Returns:
+        A formatted string of changelog entries, or None if no entries found.
+    """
+    collecting = False
+    notes_parts = []
+    for entry in data.changelog:
+        if entry.version == to_version:
+            collecting = True
+        if entry.version == from_version:
+            break
+        if collecting:
+            notes_parts.append(entry.formatted)
+    return "\n\n".join(notes_parts) if notes_parts else None
 
 
 def get_version() -> str | None:
-    """Returns the local installed version, or None if not found."""
+    """Returns the local installed version.
+
+    Returns:
+        The current version string, or None if the version file is not found.
+    """
     try:
-        with open(LOCAL_VERSION_FILE, encoding="utf-8") as f:
-            content = f.read()
-        return _extract_version(content)
+        with open(LOCAL_VERSION_FILE, "rb") as f:
+            return msgspec.toml.decode(f.read(), type=VersionData).current
     except FileNotFoundError:
         return None
 
 
-def _get_local_version(version_file):
-    """Extracts the local version from the version.py file."""
+def _get_local_version(version_file: str) -> VersionData | None:
+    """Loads and parses the local version file.
+
+    Args:
+        version_file: Absolute path to the local version TOML file.
+
+    Returns:
+        Parsed VersionData, or None if the file is not found.
+    """
     try:
-        with open(version_file, encoding="utf-8") as f:
-            content = f.read()
-        version = _extract_version(content)
-        if version:
-            click.secho(f"Local Version: {version}", fg="yellow")
-            return version
-        else:
-            click.secho("Version not found in local file.", fg="red")
-            return None
+        with open(version_file, "rb") as f:
+            data = msgspec.toml.decode(f.read(), type=VersionData)
+        click.secho(f"Local Version: {data.current}", fg="yellow")
+        return data
     except FileNotFoundError:
         click.secho("Version file not found.", fg="red")
         return None
 
 
-def _get_remote_version(url):
-    """Fetches the latest version information from the remote repository."""
+def _get_remote_version(url: str) -> VersionData | None:
+    """Fetches and parses the remote version file.
+
+    Args:
+        url: URL of the remote version TOML file.
+
+    Returns:
+        Parsed VersionData, or None if the request fails or returns a non-200 status.
+    """
     try:
         response = requests.get(url, timeout=10)
         if response.status_code == 200:
-            content = response.text
-            version = _extract_version(content)
-            if version:
-                return version, content
-            else:
-                click.secho("Version not found in remote file.", fg="red")
-                return None, None
+            return msgspec.toml.decode(response.content, type=VersionData)
         else:
             click.secho(f"Failed to fetch remote version file. Status code: {response.status_code}", fg="red")
-            return None, None
+            return None
     except requests.RequestException as e:
         click.secho(f"An error occurred while fetching the remote version file: {e}", fg="red")
-        return None, None
+        return None
 
 
-def show_release_notification():
-    """Checks for updates and notifies the user."""
+def show_release_notification() -> None:
+    """Checks for a newer remote version and notifies the user if one is available.
+
+    Reads update_notification and update_notification_verbose from config.
+    If a newer version exists, prints a notice and optionally the changelog.
+    Does nothing if update_notification is disabled in config.
+    """
     notify = cfg.upload.update_notification
     verbose = cfg.upload.update_notification_verbose
 
     if not notify:
         return
 
-    local_version = _get_local_version(LOCAL_VERSION_FILE)
-    if not local_version:
+    local_data = _get_local_version(LOCAL_VERSION_FILE)
+    if not local_data:
         return
 
-    remote_version, remote_content = _get_remote_version(REMOTE_VERSION_URL)
-    if not remote_version:
+    remote_data = _get_remote_version(REMOTE_VERSION_URL)
+    if not remote_data:
         return
 
-    if _parse_version(remote_version) > _parse_version(local_version):
-        click.secho(f"[NOTICE] Update available: v{remote_version}", fg="green", bold=True)
+    if Version(remote_data.current) > Version(local_data.current):
+        click.secho(f"[NOTICE] Update available: v{remote_data.current}", fg="green", bold=True)
 
-        if verbose and remote_content:
-            changelog = _extract_changelog(remote_content, local_version, remote_version)
+        if verbose:
+            changelog = _extract_changelog(remote_data, local_data.current, remote_data.current)
             if changelog:
                 click.secho(changelog, fg="yellow")
             else:
-                click.secho(f"Changelog not found between versions ({local_version} -> {remote_version}).", fg="yellow")
+                click.secho(
+                    f"Changelog not found between versions ({local_data.current} -> {remote_data.current}).",
+                    fg="yellow",
+                )
     else:
         click.secho("No new version available.", fg="green")

--- a/uv.lock
+++ b/uv.lock
@@ -427,11 +427,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace data/version.py with data/version.toml for structured changelog storage. Update release_notification.py to use msgspec.toml decoding and packaging.Version for version comparison, replacing regex-based parsing. Update GitHub Actions workflow to use uv and tomlkit for version file manipulation during releases.