### PR TITLE
Ensure authentication before torrent generation to prevent None announce URL

### DIFF
--- a/salmon/uploader/upload.py
+++ b/salmon/uploader/upload.py
@@ -91,6 +91,7 @@ async def prepare_and_upload(
             source_url=source_url,
             override_description=override_description,
         )
+    await gazelle_site.ensure_authenticated()
     torrent_path, torrent_content = generate_torrent(gazelle_site, path)
     files = await compile_files(path, torrent_path, metadata)
 
@@ -309,7 +310,6 @@ def generate_torrent(gazelle_site: "BaseGazelleApi", path: str) -> tuple[str, To
         Tuple of (torrent_path, torrent_object).
     """
     click.secho("Generating torrent file...", fg="yellow", nl=False)
-    await gazelle_site.ensure_authenticated()
     t = Torrent(
         path,
         trackers=[gazelle_site.announce],


### PR DESCRIPTION
When generating torrents, `gazelle_site.announce` may be accessed before
`ensure_authenticated()` has run, leaving `passkey` unset.

This results in torrents being generated with an invalid announce URL such as:

    https://tracker/None/announce

This change ensures `ensure_authenticated()` is awaited before
`generate_torrent()` is called so the passkey is available when building
the announce URL.

Tested against RED and OPS.

Fixes #293 