### PR TITLE
Extract catalog numbers from Bandcamp metadata

### DIFF
--- a/src/salmon/tagger/sources/bandcamp.py
+++ b/src/salmon/tagger/sources/bandcamp.py
@@ -8,11 +8,15 @@ from salmon.errors import GenreNotInWhitelist, ScrapeError
 from salmon.sources import BandcampBase
 from salmon.tagger.sources.base import MetadataMixin
 
+CATNO_PREFIX_RE = re.compile(r"^(?P<catno>(?=.*\d)[A-Za-z0-9][A-Za-z0-9 ._-]{1,31})\s*/\s*(?P<title>.+)$")
+
 
 class Scraper(BandcampBase, MetadataMixin):
     def parse_release_title(self, soup):
         try:
-            return soup.select("#name-section .trackTitle")[0].string.strip()
+            artist = parse_page_artist(soup)
+            _, title = extract_catno_and_title(parse_raw_release_title(soup), artist)
+            return title
         except (TypeError, IndexError) as e:
             raise ScrapeError("Failed to parse scraped title.") from e
 
@@ -57,26 +61,37 @@ class Scraper(BandcampBase, MetadataMixin):
 
     def parse_release_label(self, soup):
         try:
-            artist = ""
-            namesection = soup.select("#name-section")
-            for div in namesection:
-                span = div.find("span")
-                if span:
-                    artist = span.text.strip()
+            artist = parse_page_artist(soup)
             label = soup.select("#band-name-location .title")[0].string
             if artist != label:
                 return label
         except IndexError as e:
             raise ScrapeError("Could not parse record label.") from e
 
+    def parse_release_catno(self, soup):
+        artist = parse_page_artist(soup)
+        raw_title = parse_raw_release_title(soup)
+        catno, clean_title = extract_catno_and_title(raw_title, artist)
+        if catno:
+            return catno
+
+        current_key = normalize_release_key(clean_title)
+        artist_key = normalize_release_key(artist)
+        for album in soup.select("li.recommended-album.footer-ar[data-albumtitle][data-artist]"):
+            footer_title = album.get("data-albumtitle", "").strip()
+            footer_artist = album.get("data-artist", "").strip()
+            footer_catno, footer_clean_title = extract_catno_and_title(footer_title, footer_artist)
+            if (
+                footer_catno
+                and normalize_release_key(footer_artist) == artist_key
+                and normalize_release_key(footer_clean_title) == current_key
+            ):
+                return footer_catno
+        return None
+
     async def parse_tracks(self, soup):
         tracks = defaultdict(dict)
-        artist = ""
-        namesection = soup.select("#name-section")
-        for div in namesection:
-            span = div.find("span")
-            if span:
-                artist = span.text.strip()
+        artist = parse_page_artist(soup)
         various = artist
         tracklist_scrape = soup.select("#track_table tr.track_row_view")
         if tracklist_scrape:
@@ -104,6 +119,39 @@ class Scraper(BandcampBase, MetadataMixin):
             except (ValueError, TypeError) as e:
                 raise ScrapeError("Could not parse single track.") from e
         return dict(tracks)
+
+
+def parse_raw_release_title(soup):
+    try:
+        return soup.select("#name-section .trackTitle")[0].string.strip()
+    except (TypeError, IndexError) as e:
+        raise ScrapeError("Failed to parse scraped title.") from e
+
+
+def parse_page_artist(soup):
+    for div in soup.select("#name-section"):
+        span = div.find("span")
+        if span:
+            return span.text.strip()
+    return ""
+
+
+def extract_catno_and_title(raw_title, artist=None):
+    title = raw_title.strip()
+    match = CATNO_PREFIX_RE.match(title)
+    if not match:
+        return None, title
+
+    clean_title = match["title"].strip()
+    if artist:
+        artist_match = re.match(rf"^{re.escape(artist)}\s*-\s*(?P<title>.+)$", clean_title, flags=re.IGNORECASE)
+        if artist_match:
+            clean_title = artist_match["title"].strip()
+    return match["catno"].strip(), clean_title
+
+
+def normalize_release_key(text):
+    return re.sub(r"[^a-z0-9]+", "", text.casefold())
 
 
 def parse_artists(artist, title):

--- a/tests/test_tagger_bandcamp.py
+++ b/tests/test_tagger_bandcamp.py
@@ -1,0 +1,58 @@
+import textwrap
+
+from bs4 import BeautifulSoup
+
+from salmon.tagger.sources.bandcamp import Scraper
+
+
+def make_soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(textwrap.dedent(html), "lxml")
+
+
+def test_label_hosted_bandcamp_title_prefix_sets_catno_and_strips_display_prefix() -> None:
+    scraper = Scraper()
+    soup = make_soup("""
+        <div id="name-section">
+          <span>Marius Acke</span>
+          <div class="trackTitle">TOW014 / Marius Acke - Dirty &amp; Funky EP</div>
+        </div>
+        <div id="band-name-location">
+          <span class="title">Theory Of Swing Records</span>
+        </div>
+    """)
+
+    assert scraper.parse_release_title(soup) == "Dirty & Funky EP"
+    assert scraper.parse_release_catno(soup) == "TOW014"
+
+
+def test_artist_page_bandcamp_can_recover_catno_from_footer_label_release() -> None:
+    scraper = Scraper()
+    soup = make_soup("""
+        <div id="name-section">
+          <span>Marius Acke</span>
+          <div class="trackTitle">Dirty &amp; Funky EP</div>
+        </div>
+        <ul>
+          <li
+            class="recommended-album footer-ar"
+            data-albumtitle="TOW014 / Marius Acke - Dirty &amp; Funky EP"
+            data-artist="Marius Acke"
+          ></li>
+        </ul>
+    """)
+
+    assert scraper.parse_release_title(soup) == "Dirty & Funky EP"
+    assert scraper.parse_release_catno(soup) == "TOW014"
+
+
+def test_bandcamp_slash_titles_without_catno_are_left_unchanged() -> None:
+    scraper = Scraper()
+    soup = make_soup("""
+        <div id="name-section">
+          <span>Example Artist</span>
+          <div class="trackTitle">Love / Hate EP</div>
+        </div>
+    """)
+
+    assert scraper.parse_release_title(soup) == "Love / Hate EP"
+    assert scraper.parse_release_catno(soup) is None


### PR DESCRIPTION
## Summary
- extract Bandcamp catalog numbers from label-style release titles like `TOW014 / Artist - Release`
- recover `catno` from the footer-linked label release when the artist page is used as the clean WEB source
- add regression tests covering both Bandcamp paths and a non-catno slash title guard

Fixes #314.
