### PR TITLE
Handle multi-tracker upload failure gracefully

### DIFF
--- a/src/salmon/uploader/__init__.py
+++ b/src/salmon/uploader/__init__.py
@@ -28,7 +28,7 @@ from salmon.converter.transcoding import (
     generate_transcode_description,
     transcode_folder,
 )
-from salmon.errors import AbortAndDeleteFolder, CRCMismatchError, EditedLogError, InvalidMetadataError
+from salmon.errors import AbortAndDeleteFolder, CRCMismatchError, EditedLogError, InvalidMetadataError, RequestError
 from salmon.images import upload_cover
 from salmon.tagger import (
     metadata_validator_base,
@@ -451,59 +451,62 @@ async def upload(
             if not request_id and cfg.upload.requests.check_requests:
                 request_id = await check_requests(gazelle_site, searchstrs)
 
-            torrent_id, group_id, torrent_path, torrent_content, url = await upload_and_report(
-                gazelle_site,
-                path,
-                group_id,
-                metadata,
-                cover_url,
-                track_data,
-                hybrid,
-                lossy_master,
-                spectral_urls,
-                spectral_ids,
-                lossy_comment,
-                request_id,
-                source_url,
-                seedbox_uploader,
-                source=source,
-            )
+            try:
+                torrent_id, group_id, torrent_path, torrent_content, url = await upload_and_report(
+                    gazelle_site,
+                    path,
+                    group_id,
+                    metadata,
+                    cover_url,
+                    track_data,
+                    hybrid,
+                    lossy_master,
+                    spectral_urls,
+                    spectral_ids,
+                    lossy_comment,
+                    request_id,
+                    source_url,
+                    seedbox_uploader,
+                    source=source,
+                )
 
-            request_id = None
+                request_id = None
 
-            await print_torrents(gazelle_site, group_id, highlight_torrent_id=torrent_id)
+                await print_torrents(gazelle_site, group_id, highlight_torrent_id=torrent_id)
 
-            if cfg.upload.yes_all or click.confirm(
-                click.style("\nWould you like to check downconversion options?", fg="magenta"),
-                default=True,
-            ):
-                selected_tasks = await prompt_downconversion_choice(rls_data, track_data)
-                if selected_tasks:
-                    display_names = [task["name"] for task in selected_tasks]
-                    click.secho(
-                        f"\nSelected formats for downconversion: {', '.join(display_names)}", fg="green", bold=True
-                    )
+                if cfg.upload.yes_all or click.confirm(
+                    click.style("\nWould you like to check downconversion options?", fg="magenta"),
+                    default=True,
+                ):
+                    selected_tasks = await prompt_downconversion_choice(rls_data, track_data)
+                    if selected_tasks:
+                        display_names = [task["name"] for task in selected_tasks]
+                        click.secho(
+                            f"\nSelected formats for downconversion: {', '.join(display_names)}", fg="green", bold=True
+                        )
 
-                    # Execute downconversion tasks
-                    await execute_downconversion_tasks(
-                        selected_tasks,
-                        path,
-                        gazelle_site,
-                        group_id,
-                        metadata,
-                        cover_url,
-                        track_data,
-                        hybrid,
-                        lossy_master,
-                        spectral_urls,
-                        spectral_ids,
-                        lossy_comment,
-                        request_id,
-                        source_url,
-                        seedbox_uploader,
-                        source,
-                        url,
-                    )
+                        # Execute downconversion tasks
+                        await execute_downconversion_tasks(
+                            selected_tasks,
+                            path,
+                            gazelle_site,
+                            group_id,
+                            metadata,
+                            cover_url,
+                            track_data,
+                            hybrid,
+                            lossy_master,
+                            spectral_urls,
+                            spectral_ids,
+                            lossy_comment,
+                            request_id,
+                            source_url,
+                            seedbox_uploader,
+                            source,
+                            url,
+                        )
+            except RequestError as e:
+                click.secho(f"\nUpload to {gazelle_site.site_string} failed: {e}", fg="red", bold=True)
 
             tracker = None
             if not remaining_gazelle_sites or not cfg.upload.multi_tracker_upload:

--- a/src/salmon/uploader/upload.py
+++ b/src/salmon/uploader/upload.py
@@ -10,7 +10,6 @@ from torf import Torrent
 from salmon import cfg
 from salmon.common import str_to_int_if_int
 from salmon.constants import ARTIST_IMPORTANCES
-from salmon.errors import RequestError
 from salmon.release_notification import get_version
 from salmon.sources import SOURCE_ICONS
 from salmon.tagger.sources import METASOURCES
@@ -96,13 +95,9 @@ async def prepare_and_upload(
     files = await compile_files(path, torrent_path, metadata)
 
     click.secho("Uploading torrent...", fg="yellow")
-    try:
-        torrent_id, group_id = await gazelle_site.upload(data, files)
-        # Ensure group_id is int (upload returns tuple[int, int])
-        return torrent_id, int(group_id) if group_id else 0, torrent_path, torrent_content
-    except RequestError as e:
-        click.secho(str(e), fg="red", bold=True)
-        raise SystemExit(1) from e
+    torrent_id, group_id = await gazelle_site.upload(data, files)
+    # Ensure group_id is int (upload returns tuple[int, int])
+    return torrent_id, int(group_id) if group_id else 0, torrent_path, torrent_content
 
 
 def concat_track_data(tags: dict[str, Any], audio_info: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Problem
When uploading to multiple trackers, if the first upload succeeds but the second fails, `prepare_and_upload` raises `SystemExit(1)`. This kills the session before the `UploadManager` `finally` block can inject the first tracker's torrent into the client.

## Changes
- `prepare_and_upload` no longer catches `RequestError` / raises `SystemExit(1)` — it lets the error propagate
- The upload loop in `upload()` catches `RequestError`, prints the error, and continues to the "upload to another tracker?" prompt
- Previously queued torrent client injection tasks still execute at the end of the session

## Testing
- [ ] Upload to a single tracker — no behavior change
- [ ] Upload to two trackers where the second fails — first tracker's torrent is added to the client, session continues
- [ ] User is prompted to pick another tracker after a failure