### PR TITLE
fix: convert response headers to dict before JSON encoding in debug output

### DIFF
--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -239,7 +239,7 @@ class BaseGazelleApi:
                 if cfg.upload.debug_tracker_connection:
                     click.secho(f"[DEBUG] status: {resp.status}", fg="cyan")
                     click.secho(
-                        f"[DEBUG] response headers: {_redact(msgspec.json.encode(resp.headers).decode())}",
+                        f"[DEBUG] response headers: {_redact(msgspec.json.encode(dict(resp.headers)).decode())}",
                         fg="cyan",
                     )
                     click.secho(f"[DEBUG] response body: {_redact(text)}", fg="green")


### PR DESCRIPTION
## Summary

- Fix `TypeError` when debug tracker connection logging is enabled
- `resp.headers` (`CIMultiDictProxy`) cannot be directly serialized by `msgspec.json.encode` — wrapping it in `dict()` resolves this

## Test plan
- [ ] Enable `debug_tracker_connection` in config and verify debug output logs correctly without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)