### PR TITLE
Add --essential-only option to strip extra files during upload and conversion

### DIFF
--- a/src/salmon/common/constants.py
+++ b/src/salmon/common/constants.py
@@ -40,3 +40,7 @@ RE_FEAT = re.compile(
     flags=re.IGNORECASE,
 )
 _RE_SPLIT = re.compile("|".join(re.escape(s) for s in SPLIT_CHARS))
+
+LOSSY_EXTENSIONS = frozenset({".mp3", ".m4a", ".ogg", ".opus"})
+SCENE_EXTENSIONS = frozenset({".nfo", ".sfv", ".md5"})
+IMAGE_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png", ".pdf", ".gif"})

--- a/src/salmon/constants.py
+++ b/src/salmon/constants.py
@@ -397,3 +397,24 @@ ALLOWED_EXTENSIONS = {
     ".sfv",
     ".txt",
 }
+
+# Subset of ALLOWED_EXTENSIONS: audio, image, log, and cue files.
+# Used by --essential-only to strip nfo, sfv, md5, txt, and other extras.
+ESSENTIAL_EXTENSIONS = {
+    ".ac3",
+    ".accurip",
+    ".cue",
+    ".dts",
+    ".flac",
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".log",
+    ".m3u",
+    ".m3u8",
+    ".m4a",
+    ".m4b",
+    ".mp3",
+    ".pdf",
+    ".png",
+}

--- a/src/salmon/converter/__init__.py
+++ b/src/salmon/converter/__init__.py
@@ -16,22 +16,36 @@ from salmon.converter.transcoding import Bitrate, transcode_folder
     required=True,
     help=f"Bitrate to transcode to ({', '.join(get_args(Bitrate))})",
 )
-async def transcode(path: str, bitrate: Bitrate) -> None:
+@click.option(
+    "--essential-only",
+    "-eo",
+    is_flag=True,
+    help="Only keep music and image files; skip cues, logs and other extra files.",
+)
+async def transcode(path: str, bitrate: Bitrate, essential_only: bool) -> None:
     """Transcode a dir of FLACs into "perfect" MP3.
 
     Args:
         path: Path to the directory containing FLAC files.
         bitrate: Target bitrate (V0 or 320).
+        essential_only: Only keep music and image files.
     """
-    await transcode_folder(path, bitrate)
+    await transcode_folder(path, bitrate, essential_only=essential_only)
 
 
 @commandgroup.command()
 @click.argument("path", type=click.Path(exists=True, file_okay=False, resolve_path=True), nargs=1)
-async def downconv(path: str) -> None:
+@click.option(
+    "--essential-only",
+    "-eo",
+    is_flag=True,
+    help="Only keep music and image files; skip cues, logs and other extra files.",
+)
+async def downconv(path: str, essential_only: bool) -> None:
     """Downconvert a dir of 24bit FLACs to 16bit.
 
     Args:
         path: Path to the directory containing 24bit FLAC files.
+        essential_only: Only keep music and image files.
     """
-    await convert_folder(path)
+    await convert_folder(path, essential_only=essential_only)

--- a/src/salmon/converter/downconverting.py
+++ b/src/salmon/converter/downconverting.py
@@ -8,6 +8,7 @@ import anyio
 import asyncclick as click
 import msgspec
 
+from salmon.common.constants import IMAGE_EXTENSIONS, LOSSY_EXTENSIONS
 from salmon.common.files import process_files
 from salmon.errors import InvalidSampleRate
 from salmon.release_notification import get_version
@@ -128,13 +129,36 @@ def _collect_convert_items(
 # ---------------------------------------------------------------------------
 
 
-def _copy_extra_files(path: str, new_path: str, convert_srcs: frozenset[str]) -> None:
+def _validate_lossless(path: str) -> None:
+    """Validate that a folder contains no lossy audio files.
+
+    Args:
+        path: Path to the directory to validate.
+
+    Raises:
+        click.Abort: If a lossy file is found.
+    """
+    for _root, _, files in os.walk(path):
+        for f in files:
+            if os.path.splitext(f)[1].lower() in LOSSY_EXTENSIONS:
+                click.secho(f"A lossy file was found in the folder ({f}).", fg="red")
+                raise click.Abort
+
+
+def _copy_extra_files(
+    path: str,
+    new_path: str,
+    convert_srcs: frozenset[str],
+    *,
+    essential_only: bool = False,
+) -> None:
     """Copy non-conversion files (images, text, 16-bit audio) to the output directory.
 
     Args:
         path: Source album directory path.
         new_path: Destination album directory path.
         convert_srcs: Set of source paths that will be converted (to exclude).
+        essential_only: If True, only copy image files; skip everything else.
     """
     src_path = Path(path)
     dst_path = Path(new_path)
@@ -143,9 +167,12 @@ def _copy_extra_files(path: str, new_path: str, convert_srcs: frozenset[str]) ->
         if not p.is_file() or str(p) in convert_srcs:
             continue
         rel = p.relative_to(src_path)
+        if essential_only and p.suffix.lower() not in IMAGE_EXTENSIONS:
+            click.secho(f"Skip  {rel}", fg="yellow")
+            continue
         out = dst_path / rel
         out.parent.mkdir(parents=True, exist_ok=True)
-        click.secho(f"Copy {rel}", fg="cyan")
+        click.secho(f"Copy  {rel}", fg="cyan")
         shutil.copy(p, out)
 
 
@@ -198,6 +225,7 @@ async def convert_folder(
     path: str,
     bit_depth: BitDepth = 16,
     sample_rate: int | None = None,
+    essential_only: bool = False,
 ) -> tuple[int | None, str]:
     """Convert a folder of 24-bit FLAC files to the target bit depth.
 
@@ -205,10 +233,13 @@ async def convert_folder(
         path: Path to the source album directory.
         bit_depth: Target bit depth. Defaults to 16.
         sample_rate: Target sample rate. None for automatic detection.
+        essential_only: If True, only image files are copied; all other extra
+            files (scans, cues, logs, etc.) are skipped.
 
     Returns:
         Tuple of (final_sample_rate, new_folder_path).
     """
+    _validate_lossless(path)
     new_path = _build_output_path(path, bit_depth, sample_rate)
 
     if os.path.isdir(new_path):
@@ -217,7 +248,7 @@ async def convert_folder(
 
     items = _collect_convert_items(path, new_path, sample_rate)
     convert_srcs = frozenset(item.src for item in items)
-    _copy_extra_files(path, new_path, convert_srcs)
+    _copy_extra_files(path, new_path, convert_srcs, essential_only=essential_only)
     await _convert_audio_files(items, bit_depth)
 
     final_rate = items[-1].target_rate if items else None

--- a/src/salmon/converter/transcoding.py
+++ b/src/salmon/converter/transcoding.py
@@ -11,6 +11,7 @@ from mutagen import flac, mp3
 from mutagen.flac import VCFLACDict
 from mutagen.id3 import APIC, TXXX, Frames
 
+from salmon.common.constants import IMAGE_EXTENSIONS, LOSSY_EXTENSIONS
 from salmon.common.files import process_files
 from salmon.release_notification import get_version
 
@@ -22,7 +23,7 @@ LAME_COMMAND_MAP: dict[Bitrate, list[str]] = {
     "320": ["-h", "-b", "320"],
 }
 
-COPY_EXTENSIONS = frozenset((".jpg", ".jpeg", ".png", ".pdf", ".txt"))
+SKIP_EXTENSIONS = frozenset((".cue", ".log", ".m3u", ".m3u8", ".accurip"))
 FLAC_FOLDER_RE = re.compile(r"(24 ?bit )?FLAC", flags=re.IGNORECASE)
 LOSSLESS_FOLDER_RE = re.compile(r"Lossless", flags=re.IGNORECASE)
 
@@ -114,7 +115,7 @@ def _validate_lossless(path: str) -> None:
     for _root, _, files in os.walk(path):
         for f in files:
             ext = os.path.splitext(f)[1].lower()
-            if ext in {".mp3", ".m4a", ".ogg", ".opus"}:
+            if ext in LOSSY_EXTENSIONS:
                 click.secho(f"A lossy file was found in the folder ({f}).", fg="red")
                 raise click.Abort
 
@@ -264,21 +265,31 @@ def _copy_tags(tag_dict: dict[str, list[str]], flac_obj: flac.FLAC, mp3_path: Pa
     mp3_thing.save(v1=0, v2_version=4)
 
 
-def _copy_extra_files(path: str, new_path: str) -> None:
-    """Copy non-audio files (images, text, etc.) to the output directory.
+def _copy_extra_files(path: str, new_path: str, *, essential_only: bool = False) -> None:
+    """Copy non-audio files to the output directory.
+
+    By default all non-FLAC files are copied except those in SKIP_EXTENSIONS.
+    When essential_only is True, only image files (matching IMAGE_EXTENSIONS) are kept.
 
     Args:
         path: Source album directory path.
         new_path: Destination album directory path.
+        essential_only: If True, only copy image files; skip everything else.
     """
     src_path = Path(path)
     dst_path = Path(new_path)
 
     for p in src_path.rglob("*"):
-        if not p.is_file() or p.suffix.lower() not in COPY_EXTENSIONS:
+        if not p.is_file() or p.suffix.lower() == ".flac":
             continue
         rel = p.relative_to(src_path)
-        click.secho(f"Copy {rel}", fg="cyan")
+        if p.suffix.lower() in SKIP_EXTENSIONS:
+            click.secho(f"Skip  {rel}", fg="yellow")
+            continue
+        if essential_only and p.suffix.lower() not in IMAGE_EXTENSIONS:
+            click.secho(f"Skip  {rel}", fg="yellow")
+            continue
+        click.secho(f"Copy  {rel}", fg="cyan")
         out = dst_path / rel
         out.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(p, out)
@@ -380,12 +391,14 @@ async def _transcode_audio_files(
 # ---------------------------------------------------------------------------
 
 
-async def transcode_folder(path: str, bitrate: Bitrate) -> str:
+async def transcode_folder(path: str, bitrate: Bitrate, essential_only: bool = False) -> str:
     """Transcode a lossless folder to MP3 at the specified bitrate.
 
     Args:
         path: Path to the directory containing lossless audio files.
         bitrate: Target MP3 bitrate (e.g. "V0", "320").
+        essential_only: If True, only image files are copied; all other extra
+            files (scans, cues, logs, etc.) are skipped.
 
     Returns:
         Path to the newly created transcoded directory.
@@ -406,7 +419,7 @@ async def transcode_folder(path: str, bitrate: Bitrate) -> str:
         shutil.rmtree(new_path)
 
     items = _collect_transcode_items(path, new_path)
-    _copy_extra_files(path, new_path)
+    _copy_extra_files(path, new_path, essential_only=essential_only)
     await _transcode_audio_files(items, bitrate)
 
     return new_path

--- a/src/salmon/tagger/folderstructure.py
+++ b/src/salmon/tagger/folderstructure.py
@@ -5,11 +5,11 @@ from pathlib import Path
 import asyncclick as click
 
 from salmon import cfg
-from salmon.constants import ALLOWED_EXTENSIONS
+from salmon.constants import ALLOWED_EXTENSIONS, ESSENTIAL_EXTENSIONS
 from salmon.errors import NoncompliantFolderStructure
 
 
-async def check_folder_structure(path: str, scene: bool) -> None:
+async def check_folder_structure(path: str, scene: bool, *, essential_only: bool = False) -> None:
     """Run through every filesystem check that causes uploads to violate the rules
     or be rejected on the upload form.
 
@@ -21,6 +21,8 @@ async def check_folder_structure(path: str, scene: bool) -> None:
         path: Absolute path to the release folder being checked.
         scene: Whether the release is a scene release. Scene releases are not
             automatically fixed and require manual intervention.
+        essential_only: If True, only essential extensions are allowed;
+            files like nfo, sfv, md5, txt, etc. are flagged for removal.
 
     Raises:
         click.Abort: If the user aborts, or if a scene release has structural issues.
@@ -31,7 +33,7 @@ async def check_folder_structure(path: str, scene: bool) -> None:
             await _check_illegal_folders(path)
             _check_path_lengths(path, scene)
             _check_zero_len_folder(path)
-            await _check_extensions(path, scene)
+            await _check_extensions(path, scene, essential_only=essential_only)
             return
         except NoncompliantFolderStructure:
             if scene:
@@ -165,7 +167,7 @@ def _check_zero_len_folder(path: str) -> None:
     click.secho("No zero length folders were found.", fg="green")
 
 
-async def _check_extensions(path: str, scene: bool) -> None:
+async def _check_extensions(path: str, scene: bool, *, essential_only: bool = False) -> None:
     """Validate that all file extensions within the release folder are permitted.
 
     Files with disallowed extensions are either handled interactively (non-scene)
@@ -176,6 +178,7 @@ async def _check_extensions(path: str, scene: bool) -> None:
         path: Absolute path to the release folder being checked.
         scene: Whether the release is a scene release. Scene releases report all
             offending files at once rather than prompting per-file.
+        essential_only: If True, only essential extensions are allowed.
 
     Raises:
         NoncompliantFolderStructure: If scene release contains files with invalid
@@ -184,6 +187,7 @@ async def _check_extensions(path: str, scene: bool) -> None:
     """
     mp3, aac, flac = [], [], []
     offending_files = []  # Collect offending files for scene releases
+    effective_extensions = ESSENTIAL_EXTENSIONS if essential_only else ALLOWED_EXTENSIONS
     for root, _, files in os.walk(path):
         for fln in files:
             _, ext = os.path.splitext(fln.lower())
@@ -193,7 +197,7 @@ async def _check_extensions(path: str, scene: bool) -> None:
                 flac.append(fln)
             elif ext == ".m4a":
                 aac.append(fln)
-            elif ext not in ALLOWED_EXTENSIONS:
+            elif ext not in effective_extensions:
                 if scene:
                     offending_files.append(os.path.join(root, fln))
                 else:

--- a/src/salmon/uploader/__init__.py
+++ b/src/salmon/uploader/__init__.py
@@ -166,6 +166,12 @@ if TYPE_CHECKING:
     is_flag=True,
     help="Skip integrity check of audio files",
 )
+@click.option(
+    "--essential-only",
+    "-eo",
+    is_flag=True,
+    help="Only keep essential files; strip nfo, sfv, md5, txt, and other extras.",
+)
 async def up(
     path: str,
     group_id: int | None,
@@ -186,8 +192,11 @@ async def up(
     skip_mqa: bool,
     skip_log_check: bool,
     skip_integrity_check: bool,
+    essential_only: bool,
 ) -> None:
     """Command to upload an album folder to a Gazelle Site."""
+    if essential_only and scene:
+        raise click.UsageError("--essential-only and --scene cannot be used together.")
     if yyy:
         cfg.upload.yes_all = True
     gazelle_site = salmon.trackers.get_class(tracker)()
@@ -227,6 +236,7 @@ async def up(
         skip_mqa=skip_mqa,
         skip_log_check=skip_log_check,
         skip_integrity_check=skip_integrity_check,
+        essential_only=essential_only,
     )
 
 
@@ -250,6 +260,7 @@ async def upload(
     skip_mqa: bool = False,
     skip_log_check: bool = False,
     skip_integrity_check: bool = False,
+    essential_only: bool = False,
 ) -> None:
     """Upload an album folder to Gazelle Site.
 
@@ -275,6 +286,7 @@ async def upload(
         skip_mqa: Skip MQA check.
         skip_log_check: Skip log checking.
         skip_integrity_check: Skip integrity check.
+        essential_only: If True, only essential extensions are allowed.
     """
     path = os.path.abspath(path)
     remove_downloaded_cover_image = scene or cfg.image.remove_auto_downloaded_cover_image
@@ -357,7 +369,16 @@ async def upload(
             source_url = new_source_url
             click.secho(f"New Source URL: {source_url}", fg="yellow")
         path, metadata, tags, audio_info = await edit_metadata(
-            path, tags, metadata, source, rls_data, recompress, auto_rename, spectral_ids, skip_integrity_check
+            path,
+            tags,
+            metadata,
+            source,
+            rls_data,
+            recompress,
+            auto_rename,
+            spectral_ids,
+            skip_integrity_check,
+            essential_only,
         )
 
         if not group_id:
@@ -527,6 +548,7 @@ async def edit_metadata(
     auto_rename: bool,
     spectral_ids: dict[int, str] | None,
     skip_integrity_check: bool = False,
+    essential_only: bool = False,
 ) -> tuple[str, dict[str, Any], dict[str, "TagFile"], dict[str, dict[str, Any]]]:
     """Edit release metadata in an interactive loop until the user confirms.
 
@@ -543,6 +565,7 @@ async def edit_metadata(
         auto_rename: Whether to automatically rename files and folder.
         spectral_ids: Mapping of track index to spectral image ID, or None.
         skip_integrity_check: Whether to skip the integrity check step.
+        essential_only: If True, only essential extensions are allowed.
 
     Returns:
         A tuple of (path, metadata, tags, audio_info) after editing is complete.
@@ -561,7 +584,7 @@ async def edit_metadata(
         path = rename_folder(path, metadata, auto_rename)
         if not metadata["scene"]:
             rename_files(path, tags, metadata, auto_rename, spectral_ids, source)
-        await check_folder_structure(path, metadata["scene"])
+        await check_folder_structure(path, metadata["scene"], essential_only=essential_only)
 
         if not skip_integrity_check:
             click.secho("\nChecking integrity of audio files...", fg="cyan", bold=True)


### PR DESCRIPTION
- Add ESSENTIAL_EXTENSIONS constant for audio, image, log, and cue files
- Extract LOSSY_EXTENSIONS, SCENE_EXTENSIONS, IMAGE_EXTENSIONS to common constants
- Add --essential-only flag to up, transcode, and downconv commands
- Filter non-essential files (nfo, sfv, md5, txt, etc.) in folder structure check
- Skip non-essential files during transcoding and downconversion copy step
- Add lossy file validation to downconverting before conversion
- Replace hardcoded COPY_EXTENSIONS whitelist with SKIP_EXTENSIONS blacklist in transcoding to copy all non-skipped files by default

Fixes https://github.com/smokin-salmon/smoked-salmon/issues/50
Fixes https://github.com/smokin-salmon/smoked-salmon/issues/59