### PR TITLE
Add RED upload form enrichment for cookie-only uploads to existing groups

### DIFF
--- a/src/salmon/trackers/red.py
+++ b/src/salmon/trackers/red.py
@@ -1,5 +1,108 @@
+from aiohttp import FormData
+from bs4 import BeautifulSoup
+
 from salmon import cfg
 from salmon.trackers.base import BaseGazelleApi
+
+
+def _get_input_value(soup: BeautifulSoup, name: str) -> str | None:
+    """Get the value attribute of an input element by name.
+
+    Args:
+        soup: Parsed BeautifulSoup document.
+        name: The input name attribute.
+
+    Returns:
+        The value string, or None if input not found or value is empty.
+    """
+    tag = soup.select_one(f'input[name="{name}"]')
+    if tag is None:
+        return None
+    val = tag.get("value", "")
+    return str(val) or None
+
+
+def _get_select_value(soup: BeautifulSoup, name: str) -> str | None:
+    """Get the selected option value of a select element by name.
+
+    Args:
+        soup: Parsed BeautifulSoup document.
+        name: The select name attribute.
+
+    Returns:
+        The selected option value, or None if not found.
+    """
+    selected = soup.select_one(f'select[name="{name}"] option[selected]')
+    if selected is None:
+        return None
+    val = selected.get("value", "")
+    return str(val) or None
+
+
+def _get_textarea_value(soup: BeautifulSoup, name: str) -> str | None:
+    """Get the text content of a textarea element by name.
+
+    Args:
+        soup: Parsed BeautifulSoup document.
+        name: The textarea name attribute.
+
+    Returns:
+        The textarea text, or None if not found or empty.
+    """
+    tag = soup.select_one(f'textarea[name="{name}"]')
+    if tag is None:
+        return None
+    text = tag.get_text()
+    return text or None
+
+
+def _parse_upload_form(data: dict, soup: BeautifulSoup) -> None:
+    """Extract pre-filled fields from the upload.php form HTML.
+
+    Args:
+        data: Upload form data dict (mutated in place).
+        soup: Parsed BeautifulSoup of the upload page.
+    """
+    # --- Artists and importance ---
+    # Each artist row has an <input name="artists[]"> immediately
+    # followed by a sibling <select name="importance[]">.  We iterate
+    # row-wise so the two lists stay in lockstep.
+    artist_names: list[str] = []
+    artist_importances: list[int] = []
+    for input_tag in soup.select('input[name="artists[]"]'):
+        name = str(input_tag.get("value", ""))
+        if not name:
+            continue
+        importance = 1  # default: Main
+        sibling_select = input_tag.find_next_sibling("select", attrs={"name": "importance[]"})
+        if sibling_select is not None:
+            selected = sibling_select.select_one("option[selected]")
+            if selected is not None:
+                val = str(selected.get("value", ""))
+                if val:
+                    importance = int(val)
+        artist_names.append(name)
+        artist_importances.append(importance)
+
+    if artist_names:
+        data["artists[]"] = artist_names
+        data["importance[]"] = artist_importances
+
+    # --- Simple text inputs ---
+    for field in ("title", "year", "tags", "image"):
+        val = _get_input_value(soup, field)
+        if val is not None:
+            data[field] = val
+
+    # --- Select (dropdown) ---
+    val = _get_select_value(soup, "releasetype")
+    if val is not None:
+        data["releasetype"] = val
+
+    # --- Textarea: album description ---
+    val = _get_textarea_value(soup, "album_desc")
+    if val is not None:
+        data["album_desc"] = val
 
 
 class RedApi(BaseGazelleApi):
@@ -21,3 +124,40 @@ class RedApi(BaseGazelleApi):
                 self.dot_torrents_dir = cfg.directory.dottorrents_dir
 
         super().__init__()
+
+    async def site_page_upload(self, data: dict, files: FormData) -> tuple[int, int]:
+        """Upload torrent via upload.php with group data enrichment.
+
+        When uploading to an existing group (groupid present), fetches the
+        group info via API and populates fields that the site normally
+        pre-fills on the upload form (artists, title, year, tags, etc.).
+        This ensures the POST matches what the site expects.
+
+        Args:
+            data: Upload form data.
+            files: FormData containing files to upload.
+
+        Returns:
+            Tuple of (torrent_id, group_id).
+        """
+        group_id = data.get("groupid")
+        if group_id:
+            await self._enrich_data_from_group(data, int(group_id))
+        return await super().site_page_upload(data, files)
+
+    async def _enrich_data_from_group(self, data: dict, group_id: int) -> None:
+        """Fetch upload.php?groupid= page and scrape pre-filled fields.
+
+        Instead of relying on the API, this directly GETs the upload page
+        with the groupid parameter and parses the pre-filled form fields
+        using BeautifulSoup — the same values the site would auto-populate.
+
+        Args:
+            data: Upload form data dict (mutated in place).
+            group_id: The torrent group ID.
+        """
+        url = f"{self.base_url}/upload.php?groupid={group_id}"
+        resp = await self._request("GET", url, timeout_secs=10)
+
+        soup = BeautifulSoup(resp.text, "lxml")
+        _parse_upload_form(data, soup)

--- a/src/salmon/uploader/upload.py
+++ b/src/salmon/uploader/upload.py
@@ -214,8 +214,6 @@ def compile_data_existing_group(
     return {
         "submit": True,
         "type": 0,
-        "artists[]": [a[0] for a in metadata["artists"]],
-        "importance[]": [ARTIST_IMPORTANCES[a[1]] for a in metadata["artists"]],
         "groupid": group_id,
         "remaster": True,
         "remaster_year": metadata["year"],


### PR DESCRIPTION
- Scrape pre-filled fields (artists, title, year, tags, release type, etc.) from upload.php?groupid= page before submitting, matching what the site auto-populates in the browser
- Remove hardcoded artists/importance from compile_data_existing_group, as RED now fetches these from the upload form directly

Fixes https://github.com/smokin-salmon/smoked-salmon/issues/324