### PR TITLE
Replace FormData with UploadFiles struct and simplify upload file handling

### DIFF
--- a/src/salmon/common/__init__.py
+++ b/src/salmon/common/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import aiohttp
 import asyncclick as click
+import msgspec
 
 from salmon.common.aliases import AliasedCommands
 from salmon.common.constants import RE_FEAT
@@ -33,6 +34,7 @@ from salmon.errors import ScrapeError
 __all__ = [
     "AliasedCommands",
     "RE_FEAT",
+    "UploadFiles",
     "compress",
     "create_relative_path",
     "get_audio_files",
@@ -180,3 +182,10 @@ async def handle_scrape_errors(task: Any, mute: bool = False) -> Any | None:
         if not mute:
             click.secho(f"Unexpected scrape error: {e}\n{''.join(traceback.format_exception(e))}", fg="red", bold=True)
     return None
+
+
+class UploadFiles(msgspec.Struct):
+    """Container for files to upload (torrent and log files)."""
+
+    torrent_data: bytes
+    log_files: list[tuple[str, bytes]] = []

--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from salmon import cfg
+from salmon.common import UploadFiles
 from salmon.constants import RELEASE_TYPES
 from salmon.errors import (
     LoginError,
@@ -61,39 +62,58 @@ def _redact(text: str) -> str:
     return _SENSITIVE_KEYS.sub(lambda m: f'"{m.group(1)}": "[REDACTED]"', text)
 
 
-def _compose_form_data(files: FormData, data: dict[str, Any]) -> FormData:
-    """Compose FormData by adding data fields with proper value conversion.
+def _add_form_field(form: FormData, key: str, value: Any) -> None:
+    """Add a single value to FormData, coercing types as needed.
+
+    aiohttp FormData only accepts str/bytes/IO types, so bool and int
+    values are converted accordingly. False and None are skipped.
 
     Args:
-        files: The FormData object containing file uploads.
+        form: The FormData instance to add the field to.
+        key: The field name.
+        value: The field value.
+    """
+    if value is True:
+        form.add_field(key, "on")
+    elif value is False or value is None:
+        return
+    elif isinstance(value, int):
+        form.add_field(key, str(value))
+    else:
+        form.add_field(key, value)
+
+
+def _compose_form_data(files: UploadFiles, data: dict[str, Any]) -> FormData:
+    """Compose FormData by converting UploadFiles and adding data fields.
+
+    Args:
+        files: The UploadFiles object containing file uploads.
         data: Dictionary of field names and values to add.
 
     Returns:
-        The FormData object with all fields added.
+        A new FormData object with all files and fields added.
     """
+    form = FormData()
+    form.add_field(
+        "file_input",
+        files.torrent_data,
+        filename="meowmeow.torrent",
+        content_type="application/octet-stream",
+    )
+    for log_name, log_data in files.log_files:
+        form.add_field(
+            "logfiles[]",
+            log_data,
+            filename=log_name,
+            content_type="application/octet-stream",
+        )
     for key, value in data.items():
         if isinstance(value, list):
             for item in value:
-                # aiohttp FormData only accepts str/bytes/IO types, not int/bool
-                if item is True:
-                    files.add_field(key, "on")
-                elif item is False or item is None:
-                    continue
-                elif isinstance(item, int):
-                    files.add_field(key, str(item))
-                else:
-                    files.add_field(key, item)
+                _add_form_field(form, key, item)
         else:
-            # aiohttp FormData only accepts str/bytes/IO types, not int/bool
-            if value is True:
-                files.add_field(key, "on")
-            elif value is False or value is None:
-                continue
-            elif isinstance(value, int):
-                files.add_field(key, str(value))
-            else:
-                files.add_field(key, value)
-    return files
+            _add_form_field(form, key, value)
+    return form
 
 
 class SearchReleaseData(msgspec.Struct, frozen=True):
@@ -327,7 +347,6 @@ class BaseGazelleApi:
         Returns:
             The torrent group data.
         """
-        await self.ensure_authenticated()
         return await self.api_call("torrentgroup", params={"id": group_id})
 
     async def get_redirect_torrentgroupid(self, torrentid: int) -> int | None:
@@ -362,7 +381,6 @@ class BaseGazelleApi:
         Returns:
             The request data.
         """
-        await self.ensure_authenticated()
         return await self.api_call("request", params={"id": id})
 
     async def artist_rls(self, artist: str):
@@ -374,7 +392,6 @@ class BaseGazelleApi:
         Returns:
             Tuple of (artist_id, list of releases).
         """
-        await self.ensure_authenticated()
         resp = await self.api_call("artist", params={"artistname": artist})
         releases = []
         for group in resp["torrentgroup"]:
@@ -495,12 +512,12 @@ class BaseGazelleApi:
             recent_uploads += self.parse_uploads_from_log_html(page_text)
         return recent_uploads
 
-    async def api_key_upload(self, data: dict, files: FormData) -> tuple[int, int]:
+    async def api_key_upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
         """Upload torrent via API.
 
         Args:
             data: Upload form data.
-            files: FormData containing files to upload.
+            files: UploadFiles containing files to upload.
 
         Returns:
             Tuple of (torrent_id, group_id).
@@ -508,13 +525,12 @@ class BaseGazelleApi:
         Raises:
             RequestError: If upload fails.
         """
-        await self.ensure_authenticated()
         url = self.base_url + "/ajax.php?action=upload"
         data["auth"] = self.authkey
 
-        _compose_form_data(files, data)
-
-        response = await self._request("POST", url, data=files, timeout_secs=30, prefer_api_key=True)
+        response = await self._request(
+            "POST", url, data=_compose_form_data(files, data), timeout_secs=30, prefer_api_key=True
+        )
         try:
             resp = msgspec.json.decode(response.text)
         except (msgspec.DecodeError, ValueError) as e:
@@ -526,40 +542,38 @@ class BaseGazelleApi:
         try:
             if resp["status"] != "success":
                 raise RequestError(f"API upload failed: {resp['error']}")
-            elif resp["status"] == "success":
-                if ("requestid" in resp["response"] and resp["response"]["requestid"]) or (
-                    "fillRequest" in resp["response"]
-                    and resp["response"]["fillRequest"]
-                    and resp["response"]["fillRequest"]["requestId"]
-                ):
-                    requestId = (
-                        resp["response"]["requestid"]
-                        if "requestid" in resp["response"]
-                        else resp["response"]["fillRequest"]["requestId"]
-                    )
-                    if requestId == -1:
-                        click.secho("Request fill failed!", fg="red")
-                    else:
-                        click.secho("Filled request: " + self.request_url(requestId), fg="green")
-                torrent_id = 0
-                group_id = 0
-                if "torrentid" in resp["response"]:
-                    torrent_id = resp["response"]["torrentid"]
-                    group_id = resp["response"]["groupid"]
-                elif "torrentId" in resp["response"]:
-                    torrent_id = resp["response"]["torrentId"]
-                    group_id = resp["response"]["groupId"]
-                return torrent_id, group_id
+            if ("requestid" in resp["response"] and resp["response"]["requestid"]) or (
+                "fillRequest" in resp["response"]
+                and resp["response"]["fillRequest"]
+                and resp["response"]["fillRequest"]["requestId"]
+            ):
+                requestId = (
+                    resp["response"]["requestid"]
+                    if "requestid" in resp["response"]
+                    else resp["response"]["fillRequest"]["requestId"]
+                )
+                if requestId == -1:
+                    click.secho("Request fill failed!", fg="red")
+                else:
+                    click.secho("Filled request: " + self.request_url(requestId), fg="green")
+            torrent_id = 0
+            group_id = 0
+            if "torrentid" in resp["response"]:
+                torrent_id = resp["response"]["torrentid"]
+                group_id = resp["response"]["groupid"]
+            elif "torrentId" in resp["response"]:
+                torrent_id = resp["response"]["torrentId"]
+                group_id = resp["response"]["groupId"]
+            return torrent_id, group_id
         except TypeError as err:
             raise RequestError(f"API upload failed, response: {resp}") from err
-        raise RequestError("API upload failed: unexpected response format")
 
-    async def site_page_upload(self, data: dict, files: FormData) -> tuple[int, int]:
+    async def site_page_upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
         """Upload torrent via upload.php.
 
         Args:
             data: Upload form data.
-            files: FormData containing files to upload.
+            files: UploadFiles containing files to upload.
 
         Returns:
             Tuple of (torrent_id, group_id).
@@ -567,16 +581,13 @@ class BaseGazelleApi:
         Raises:
             RequestError: If upload fails.
         """
-        await self.ensure_authenticated()
         if "groupid" in data:
             url = self.base_url + f"/upload.php?groupid={data['groupid']}"
         else:
             url = self.base_url + "/upload.php"
         data["auth"] = self.authkey
 
-        _compose_form_data(files, data)
-
-        response = await self._request("POST", url, data=files, timeout_secs=30)
+        response = await self._request("POST", url, data=_compose_form_data(files, data), timeout_secs=30)
         resp_text = response.text
         resp_url = response.url
 
@@ -604,12 +615,12 @@ class BaseGazelleApi:
         except TypeError as err:
             raise RequestError(f"Site upload failed, response text: {resp_text}") from err
 
-    async def upload(self, data: dict, files: FormData) -> tuple[int, int]:
+    async def upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
         """Upload torrent via API or upload.php.
 
         Args:
             data: Upload form data.
-            files: FormData containing files to upload.
+            files: UploadFiles containing files to upload.
 
         Returns:
             Tuple of (torrent_id, group_id).
@@ -633,7 +644,6 @@ class BaseGazelleApi:
         Raises:
             RequestError: If report fails.
         """
-        await self.ensure_authenticated()
         url = self.base_url + "/reportsv2.php"
         type_ = "lossywebapproval" if source == "WEB" else "lossyapproval"
         data = {
@@ -659,7 +669,6 @@ class BaseGazelleApi:
         Raises:
             RequestError: If edit fails.
         """
-        await self.ensure_authenticated()
         current_details = await self.api_call("torrent", params={"id": torrent_id})
         new_data = {
             "action": "takeedit",

--- a/src/salmon/trackers/dic.py
+++ b/src/salmon/trackers/dic.py
@@ -1,7 +1,7 @@
 import asyncclick as click
-from aiohttp import FormData
 
 from salmon import cfg
+from salmon.common import UploadFiles
 from salmon.trackers.base import BaseGazelleApi
 
 
@@ -28,12 +28,12 @@ class DICApi(BaseGazelleApi):
 
         super().__init__()
 
-    async def upload(self, data: dict, files: FormData) -> tuple[int, int]:
+    async def upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
         """Attempt to upload a torrent to the site using the upload.php.
 
         Args:
             data: Upload form data dictionary.
-            files: FormData containing files to upload.
+            files: UploadFiles containing files to upload.
 
         Returns:
             Tuple of (torrent_id, group_id) from the upload response.

--- a/src/salmon/trackers/ops.py
+++ b/src/salmon/trackers/ops.py
@@ -1,10 +1,10 @@
 import re
 
 import asyncclick as click
-from aiohttp import FormData
 from bs4 import BeautifulSoup
 
 from salmon import cfg
+from salmon.common import UploadFiles
 from salmon.errors import (
     RequestError,
 )
@@ -54,7 +54,7 @@ class OpsApi(BaseGazelleApi):
             "Unknown": 21,
         }
 
-    async def upload(self, data: dict, files: FormData) -> tuple[int, int]:
+    async def upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
         """Upload torrent, prompting once to set release type to Split for multi-artist releases.
 
         If the upload is for a new group (has 'releasetype' in data) and two or more
@@ -63,7 +63,7 @@ class OpsApi(BaseGazelleApi):
 
         Args:
             data: Upload form data.
-            files: FormData containing files to upload.
+            files: UploadFiles containing files to upload.
 
         Returns:
             Tuple of (torrent_id, group_id).
@@ -126,7 +126,6 @@ class OpsApi(BaseGazelleApi):
         Raises:
             RequestError: If the report fails.
         """
-        await self.ensure_authenticated()
         url = self.base_url + "/reportsv2.php"
         # OPS only uses lossyapproval, not lossywebapproval
         data = {

--- a/src/salmon/trackers/red.py
+++ b/src/salmon/trackers/red.py
@@ -1,7 +1,7 @@
-from aiohttp import FormData
 from bs4 import BeautifulSoup
 
 from salmon import cfg
+from salmon.common import UploadFiles
 from salmon.trackers.base import BaseGazelleApi
 
 
@@ -125,7 +125,25 @@ class RedApi(BaseGazelleApi):
 
         super().__init__()
 
-    async def site_page_upload(self, data: dict, files: FormData) -> tuple[int, int]:
+    async def upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
+        """Upload torrent, using site page upload when log files are present.
+
+        Temporary patch: API key upload has a bug where log scores are not
+        announced in IRC. Force site page upload until it's fixed.
+
+        Args:
+            data: Upload form data.
+            files: UploadFiles containing files to upload.
+
+        Returns:
+            Tuple of (torrent_id, group_id).
+        """
+        if files.log_files:
+            return await self.site_page_upload(data, files)
+
+        return await super().upload(data, files)
+
+    async def site_page_upload(self, data: dict, files: UploadFiles) -> tuple[int, int]:
         """Upload torrent via upload.php with group data enrichment.
 
         When uploading to an existing group (groupid present), fetches the
@@ -135,7 +153,7 @@ class RedApi(BaseGazelleApi):
 
         Args:
             data: Upload form data.
-            files: FormData containing files to upload.
+            files: UploadFiles containing files to upload.
 
         Returns:
             Tuple of (torrent_id, group_id).

--- a/src/salmon/uploader/upload.py
+++ b/src/salmon/uploader/upload.py
@@ -4,11 +4,10 @@ from typing import TYPE_CHECKING, Any
 
 import anyio
 import asyncclick as click
-from aiohttp import FormData
 from torf import Torrent
 
 from salmon import cfg
-from salmon.common import str_to_int_if_int
+from salmon.common import UploadFiles, str_to_int_if_int
 from salmon.constants import ARTIST_IMPORTANCES
 from salmon.release_notification import get_version
 from salmon.sources import SOURCE_ICONS
@@ -92,7 +91,7 @@ async def prepare_and_upload(
         )
     await gazelle_site.ensure_authenticated()
     torrent_path, torrent_content = generate_torrent(gazelle_site, path)
-    files = await compile_files(path, torrent_path, metadata)
+    files = await compile_files(path, torrent_content, metadata)
 
     click.secho("Uploading torrent...", fg="yellow")
     torrent_id, group_id = await gazelle_site.upload(data, files)
@@ -235,45 +234,35 @@ def compile_data_existing_group(
     }
 
 
-async def compile_files(path: str, torrent_path: str, metadata: dict[str, Any]) -> FormData:
+async def compile_files(path: str, torrent_content: Torrent, metadata: dict[str, Any]) -> UploadFiles:
     """Compile files to upload (torrent and log files).
 
     Args:
         path: Path to the album folder.
-        torrent_path: Path to the torrent file.
+        torrent_content: Torrent object.
         metadata: Release metadata.
 
     Returns:
-        FormData containing files to upload.
+        UploadFiles containing file data for upload.
     """
-    files = FormData()
-    async with await anyio.open_file(torrent_path, "rb") as torrent_file:
-        files.add_field(
-            "file_input",
-            await torrent_file.read(),
-            filename="meowmeow.torrent",
-            content_type="application/octet-stream",
-        )
-    if metadata["source"] == "CD":
-        await attach_logfiles(path, files)
-    return files
+    torrent_data = torrent_content.dump()
+    log_files = await collect_logfiles(path) if metadata["source"] == "CD" else []
+    return UploadFiles(torrent_data=torrent_data, log_files=log_files)
 
 
-async def attach_logfiles(path: str, files: FormData) -> None:
-    """Attach all log files for upload.
+async def collect_logfiles(path: str) -> list[tuple[str, bytes]]:
+    """Collect all log files for upload.
 
     Args:
         path: Path to the album folder.
-        files: FormData to add log files to.
+
+    Returns:
+        List of (filename, file_bytes) tuples for each log file found.
     """
-    for root, _, filenames in os.walk(path):
-        for filename in filenames:
-            if filename.lower().endswith(".log"):
-                filepath = os.path.abspath(os.path.join(root, filename))
-                async with await anyio.open_file(filepath, "rb") as f:
-                    files.add_field(
-                        "logfiles[]", await f.read(), filename=filename, content_type="application/octet-stream"
-                    )
+    log_files: list[tuple[str, bytes]] = []
+    async for filepath in anyio.Path(path).rglob("*.log"):
+        log_files.append((filepath.name, await filepath.read_bytes()))
+    return log_files
 
 
 def generate_catno(metadata: dict[str, Any]) -> str:


### PR DESCRIPTION
- Add UploadFiles struct to hold torrent data and log files as plain bytes
- Move FormData composition into _compose_form_data, keeping upload methods free of aiohttp-specific types
- Extract _add_form_field helper to deduplicate type coercion logic
- Serialize torrent directly from Torrent object instead of reading from disk
- Rename attach_logfiles to collect_logfiles, returning a list instead of mutating FormData
- Force RED to use site page upload when log files are present to work around API key upload bug with log score IRC announcements
- Remove redundant ensure_authenticated calls already handled by _request