### PR TITLE
Add display_host config for web interface and bind to 0.0.0.0 by default

### DIFF
--- a/src/salmon/config/validations.py
+++ b/src/salmon/config/validations.py
@@ -153,13 +153,22 @@ class UploadDescription(BaseStruct):
 
 
 class UploadWebInterface(BaseStruct):
-    host: str = "127.0.0.1"
+    host: str = "0.0.0.0"
     port: int = 55110
+    display_host: str = "localhost"
     static_root_url: str = "/static"
 
     def __post_init__(self):
         if self.port < 1 or self.port > 65535:
             raise ValueError("Port number is invalid")
+
+    @property
+    def effective_host(self) -> str:
+        """Host used for generating user-facing URLs.
+
+        Falls back to ``host`` when ``display_host`` is not set.
+        """
+        return self.display_host if self.display_host else self.host
 
 
 class UploadRequests(BaseStruct):

--- a/src/salmon/data/config.default.toml
+++ b/src/salmon/data/config.default.toml
@@ -192,8 +192,13 @@ session = 'get-from-site-cookie'
 
 # [upload.web_interface]
 # # web interface settings
-# host = "127.0.0.1"
+# host = "0.0.0.0"
 # port = 55110
+
+# Host used in generated URLs (e.g. spectral viewer links).
+# Set to "" to use the value of "host".
+# display_host = "localhost"
+
 # static_root_url = "/static"
 
 # [upload.requests]

--- a/src/salmon/uploader/spectrals.py
+++ b/src/salmon/uploader/spectrals.py
@@ -407,7 +407,7 @@ async def _open_specs_in_web_server(specs_path, all_spectral_ids):
             os.symlink(specs_path, symlink_path)
         with contextlib.suppress(WebServerIsAlreadyRunning):
             runner = await create_app_async()
-        url = f"http://{cfg.upload.web_interface.host}:{cfg.upload.web_interface.port}/spectrals"
+        url = f"http://{cfg.upload.web_interface.effective_host}:{cfg.upload.web_interface.port}/spectrals"
         await prompt_async(
             click.style(
                 f"\nSpectrals are available at {click.style(url, fg='blue', underline=True)}\n"

--- a/src/salmon/web/__init__.py
+++ b/src/salmon/web/__init__.py
@@ -18,7 +18,7 @@ web_cfg = cfg.upload.web_interface
 @commandgroup.command()
 async def web_cmd() -> None:
     """Start the salmon web server."""
-    click.secho(f"Running webserver on http://{web_cfg.host}:{web_cfg.port}", fg="cyan")
+    click.secho(f"Running webserver on http://{web_cfg.effective_host}:{web_cfg.port}", fg="cyan")
     runner = await create_app_async()
     try:
         # Keep the server running


### PR DESCRIPTION
- Change default web interface host from 127.0.0.1 to 0.0.0.0
- Add display_host setting for user-facing URLs (defaults to localhost)
- Use display_host in spectral viewer link and web server startup message
- Update default config with display_host documentation

Fixes https://github.com/smokin-salmon/smoked-salmon/issues/308