### PR TITLE
Add `default_spectral_ids` to config options 

### DIFF
--- a/src/salmon/config/validations.py
+++ b/src/salmon/config/validations.py
@@ -25,6 +25,7 @@ class Directory(BaseStruct):
 
 
 ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "imgbb", "imgbox"]
+SpectralSelectionLiteral = Literal["*", "+", "0"]
 
 
 class ImageUploader(BaseStruct):
@@ -37,6 +38,7 @@ class ImageUploader(BaseStruct):
     imgbb_key: str | None = None
     remove_auto_downloaded_cover_image: bool = False
     auto_compress_cover: bool = False
+    default_spectral_ids: SpectralSelectionLiteral | None = None
 
     def __post_init__(self):
         uploader_selections = set({self.image_uploader, self.cover_uploader, self.specs_uploader})

--- a/src/salmon/data/config.default.toml
+++ b/src/salmon/data/config.default.toml
@@ -34,6 +34,10 @@ image_uploader = "ptpimg"
 cover_uploader = "ptpimg"
 specs_uploader = "ptpimg"
 
+# Default selection for "What spectral IDs would you like to upload?" prompt.
+# "*" = all, "+" = randomized selection, "0" = none. Leave unset to use context-based default.
+# default_spectral_ids = "*"
+
 # ptpimg API key (log into ptpimg, developpers tools, go to the Elements tab, and search for 'api_key')
 ptpimg_key = 'api_key'
 # ptscreens API key (log into ptscreens, settings, API)

--- a/src/salmon/uploader/spectrals.py
+++ b/src/salmon/uploader/spectrals.py
@@ -495,7 +495,9 @@ async def prompt_spectrals(spectral_ids, lossy_master, check_lma, force_prompt_l
                     '(space-separated list of IDs, "0" for none, "*" for all, or "+" for a randomized selection)',
                     fg="magenta",
                 ),
-                default="*" if lossy_master else "+",
+                default=cfg.image.default_spectral_ids
+                if cfg.image.default_spectral_ids is not None
+                else ("*" if lossy_master else "+"),
             )
         )
         if ids.strip() == "+":


### PR DESCRIPTION
Adds a new config option `default_spectral_ids` under `[image]` that lets users set a persistent default answer for the "What spectral IDs would you like to upload?" prompt.

Changes:

- `ImageUploader` config struct gains default_spectral_ids: "*" | "+" | "0" | None (default: None)
- `prompt_spectrals() ` uses the config value as the prompt default when set, otherwise falls back to the existing context-aware default (`"*"` for lossy master releases, `"+"` for others)
- `config.default.toml` documents the new option as a commented-out example
Usage:

Add to your `config.toml` under `[image]`:


`default_spectral_ids = "*"  # upload all by default`
