### PR TITLE
fix(trackers): harden RED cookie-backed uploads

### DIFF
--- a/src/salmon/config/validations.py
+++ b/src/salmon/config/validations.py
@@ -75,6 +75,7 @@ class Metadata(BaseStruct):
 
 class GazelleTrackerSettings(BaseStruct):
     session: str
+    keeplogged: str | None = None
     api_key: str | None = None
     # TODO: validate this
     dottorrents_dir: str | None = None

--- a/src/salmon/data/config.default.toml
+++ b/src/salmon/data/config.default.toml
@@ -85,18 +85,21 @@ default_tracker = 'RED'       # If not set, you'll be prompted to choose when us
 # Authentication (Replace with valid session keys or API keys)
 [tracker.red]
 session = 'get-from-site-cookie' # Required for now (waiting on API support)
+# keeplogged = 'optional-keep-me-logged-in-cookie' # Needed on some Gazelle sites when session alone loops to login
 # api_key = 'red-api-key'          # Needs uploading privileges (optional for now)
 # In case you want separate output folders for .torrent files
 # dottorrents_dir = 'path to dir'
 
 [tracker.ops]
 session = 'get-from-site-cookie'
+# keeplogged = 'optional-keep-me-logged-in-cookie'
 # api_key = 'ops-api-key'          # Needs uploading privileges (optional for now)
 # In case you want separate output folders for .torrent files
 # dottorrents_dir = 'path to ops dir'
 
 [tracker.dic]
 session = 'get-from-site-cookie'
+# keeplogged = 'optional-keep-me-logged-in-cookie'
 # api_key = 'dic-api-key'          # DIC does not support API key authentication for now
 # In case you want separate output folders for .torrent files
 # dottorrents_dir = 'path to dic dir'

--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -4,7 +4,7 @@ import re
 from contextlib import suppress
 from http import HTTPStatus
 from typing import Any, cast
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import aiohttp
 import asyncclick as click
@@ -60,6 +60,23 @@ def _redact(text: str) -> str:
         The string with sensitive values replaced.
     """
     return _SENSITIVE_KEYS.sub(lambda m: f'"{m.group(1)}": "[REDACTED]"', text)
+
+
+def _normalize_session_cookie(cookie: str) -> str:
+    """Normalize session cookies so aiohttp sends them in a browser-like form.
+
+    RED-style session cookies often contain characters like `/`, `+`, `:`, and `=`.
+    If we pass the decoded value directly into aiohttp's cookie jar, it gets wrapped
+    in quotes when serialized into the Cookie header. Normalizing to a canonical
+    percent-encoded form keeps the header unquoted and matches what browsers send.
+
+    Args:
+        cookie: Raw or already-encoded session cookie value from config.
+
+    Returns:
+        Canonical percent-encoded cookie value.
+    """
+    return quote(unquote(cookie.strip()), safe="")
 
 
 def _add_form_field(form: FormData, key: str, value: Any) -> None:
@@ -173,7 +190,7 @@ class BaseGazelleApi:
 
     def _get_cookies(self) -> dict[str, str]:
         """Get cookies dict for requests."""
-        return {"session": self.cookie}
+        return {"session": _normalize_session_cookie(self.cookie)}
 
     @property
     def announce(self) -> str:

--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -79,6 +79,22 @@ def _normalize_session_cookie(cookie: str) -> str:
     return quote(unquote(cookie.strip()), safe="")
 
 
+def _build_tracker_cookies(session_cookie: str, keeplogged_cookie: str | None = None) -> dict[str, str]:
+    """Build the cookie payload for tracker requests.
+
+    Args:
+        session_cookie: The tracker session cookie value.
+        keeplogged_cookie: Optional persistent-login cookie value.
+
+    Returns:
+        Cookie mapping ready for aiohttp.
+    """
+    cookies = {"session": _normalize_session_cookie(session_cookie)}
+    if keeplogged_cookie:
+        cookies["keeplogged"] = keeplogged_cookie.strip()
+    return cookies
+
+
 def _add_form_field(form: FormData, key: str, value: Any) -> None:
     """Add a single value to FormData, coercing types as needed.
 
@@ -169,6 +185,7 @@ class BaseGazelleApi:
     site_code: str
     site_string: str
     api_key: str = ""  # Optional, only for API key upload
+    keeplogged: str | None = None
 
     # Rate limiter: 5 requests per 10 seconds (shared across all instances)
     _rate_limiter = AsyncLimiter(5, 10)
@@ -190,7 +207,7 @@ class BaseGazelleApi:
 
     def _get_cookies(self) -> dict[str, str]:
         """Get cookies dict for requests."""
-        return {"session": _normalize_session_cookie(self.cookie)}
+        return _build_tracker_cookies(self.cookie, self.keeplogged)
 
     @property
     def announce(self) -> str:

--- a/src/salmon/trackers/dic.py
+++ b/src/salmon/trackers/dic.py
@@ -23,6 +23,7 @@ class DICApi(BaseGazelleApi):
                 self.dot_torrents_dir = cfg.directory.dottorrents_dir
 
             self.cookie = dic_cfg.session
+            self.keeplogged = dic_cfg.keeplogged
             if dic_cfg.api_key:
                 self.api_key = dic_cfg.api_key
 

--- a/src/salmon/trackers/ops.py
+++ b/src/salmon/trackers/ops.py
@@ -29,6 +29,7 @@ class OpsApi(BaseGazelleApi):
                 self.dot_torrents_dir = cfg.directory.dottorrents_dir
 
             self.cookie = ops_cfg.session
+            self.keeplogged = ops_cfg.keeplogged
             if ops_cfg.api_key:
                 self.api_key = ops_cfg.api_key
 

--- a/src/salmon/trackers/red.py
+++ b/src/salmon/trackers/red.py
@@ -115,6 +115,7 @@ class RedApi(BaseGazelleApi):
             red_cfg = cfg.tracker.red
 
             self.cookie = red_cfg.session
+            self.keeplogged = red_cfg.keeplogged
             if red_cfg.api_key:
                 self.api_key = red_cfg.api_key
 

--- a/src/salmon/trackers/red.py
+++ b/src/salmon/trackers/red.py
@@ -1,7 +1,9 @@
+import asyncclick as click
 from bs4 import BeautifulSoup
 
 from salmon import cfg
 from salmon.common import UploadFiles
+from salmon.errors import LoginError
 from salmon.trackers.base import BaseGazelleApi
 
 
@@ -130,7 +132,9 @@ class RedApi(BaseGazelleApi):
         """Upload torrent, using site page upload when log files are present.
 
         Temporary patch: API key upload has a bug where log scores are not
-        announced in IRC. Force site page upload until it's fixed.
+        announced in IRC. Prefer site page upload when cookie auth works, but
+        fall back to API upload if the cookie-backed path is unavailable and an
+        API key is configured.
 
         Args:
             data: Upload form data.
@@ -140,7 +144,18 @@ class RedApi(BaseGazelleApi):
             Tuple of (torrent_id, group_id).
         """
         if files.log_files:
-            return await self.site_page_upload(data, files)
+            if not self.api_key:
+                return await self.site_page_upload(data, files)
+
+            try:
+                return await self.site_page_upload(data, files)
+            except LoginError:
+                click.secho(
+                    "RED cookie auth failed for upload.php; falling back to API upload. "
+                    "Log score IRC announcements may be incomplete on RED for this upload.",
+                    fg="yellow",
+                )
+                return await self.api_key_upload(data, files)
 
         return await super().upload(data, files)
 

--- a/tests/test_trackers_base.py
+++ b/tests/test_trackers_base.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import aiohttp
+from yarl import URL
+
+from salmon.trackers.base import _normalize_session_cookie
+
+
+def test_normalize_session_cookie_encodes_decoded_red_style_values() -> None:
+    decoded = (
+        "NYzc/MwZxhjA8VKzFuyi0HcVN/TiaCiwgOAx+4rKhpWQsNLtfImjNY1xJzForZ3UUP+uo66wrrv7J6V5OrXnsb+Q"
+        "kvCP6H6bXMJ2jqElXZJf+xMfryUSE4pocW8IaeRk:Jcc5R/l9nvCJpY8hI7uKpA=="
+    )
+
+    assert _normalize_session_cookie(decoded) == (
+        "NYzc%2FMwZxhjA8VKzFuyi0HcVN%2FTiaCiwgOAx%2B4rKhpWQsNLtfImjNY1xJzForZ3UUP%2Buo66wrrv7J6V5"
+        "OrXnsb%2BQkvCP6H6bXMJ2jqElXZJf%2BxMfryUSE4pocW8IaeRk%3AJcc5R%2Fl9nvCJpY8hI7uKpA%3D%3D"
+    )
+
+
+def test_normalize_session_cookie_is_idempotent_for_encoded_values() -> None:
+    encoded = (
+        "NYzc%2FMwZxhjA8VKzFuyi0HcVN%2FTiaCiwgOAx%2B4rKhpWQsNLtfImjNY1xJzForZ3UUP%2Buo66wrrv7J6V5"
+        "OrXnsb%2BQkvCP6H6bXMJ2jqElXZJf%2BxMfryUSE4pocW8IaeRk%3AJcc5R%2Fl9nvCJpY8hI7uKpA%3D%3D"
+    )
+
+    assert _normalize_session_cookie(encoded) == encoded
+
+
+def test_normalized_cookie_header_is_not_quoted() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        jar = aiohttp.CookieJar(loop=loop)
+        url = URL("https://redacted.sh/ajax.php?action=index")
+        jar.update_cookies(
+            {"session": _normalize_session_cookie("abc/def+ghi:jkl==")},
+            response_url=url,
+        )
+
+        assert jar.filter_cookies(url).output(header="Cookie:") == "Cookie: session=abc%2Fdef%2Bghi%3Ajkl%3D%3D"
+    finally:
+        loop.close()

--- a/tests/test_trackers_base.py
+++ b/tests/test_trackers_base.py
@@ -3,7 +3,10 @@ import asyncio
 import aiohttp
 from yarl import URL
 
-from salmon.trackers.base import _normalize_session_cookie
+from salmon.trackers.base import (
+    _build_tracker_cookies,
+    _normalize_session_cookie,
+)
 
 
 def test_normalize_session_cookie_encodes_decoded_red_style_values() -> None:
@@ -40,3 +43,10 @@ def test_normalized_cookie_header_is_not_quoted() -> None:
         assert jar.filter_cookies(url).output(header="Cookie:") == "Cookie: session=abc%2Fdef%2Bghi%3Ajkl%3D%3D"
     finally:
         loop.close()
+
+
+def test_build_tracker_cookies_includes_optional_keeplogged() -> None:
+    assert _build_tracker_cookies("abc/def", "keep-me") == {
+        "session": "abc%2Fdef",
+        "keeplogged": "keep-me",
+    }

--- a/tests/test_trackers_red.py
+++ b/tests/test_trackers_red.py
@@ -1,0 +1,25 @@
+import pytest
+
+from salmon.common import UploadFiles
+from salmon.errors import LoginError
+from salmon.trackers.red import RedApi
+
+
+@pytest.mark.anyio
+async def test_red_upload_falls_back_to_api_when_cookie_upload_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracker = RedApi()
+    tracker.api_key = "test-api-key"
+
+    files = UploadFiles(torrent_data=b"torrent", log_files=[("rip.log", b"log")])
+    expected = (123, 456)
+
+    async def fail_site_page_upload(data: dict, files: UploadFiles) -> tuple[int, int]:
+        raise LoginError
+
+    async def ok_api_upload(data: dict, files: UploadFiles) -> tuple[int, int]:
+        return expected
+
+    monkeypatch.setattr(tracker, "site_page_upload", fail_site_page_upload)
+    monkeypatch.setattr(tracker, "api_key_upload", ok_api_upload)
+
+    assert await tracker.upload({}, files) == expected

--- a/tests/test_trackers_red.py
+++ b/tests/test_trackers_red.py
@@ -1,25 +1,20 @@
-import pytest
+import unittest
+from unittest.mock import AsyncMock
 
 from salmon.common import UploadFiles
 from salmon.errors import LoginError
 from salmon.trackers.red import RedApi
 
 
-@pytest.mark.anyio
-async def test_red_upload_falls_back_to_api_when_cookie_upload_fails(monkeypatch: pytest.MonkeyPatch) -> None:
-    tracker = RedApi()
-    tracker.api_key = "test-api-key"
+class TestRedUploadFallback(unittest.IsolatedAsyncioTestCase):
+    async def test_red_upload_falls_back_to_api_when_cookie_upload_fails(self) -> None:
+        tracker = RedApi()
+        tracker.api_key = "test-api-key"
 
-    files = UploadFiles(torrent_data=b"torrent", log_files=[("rip.log", b"log")])
-    expected = (123, 456)
+        files = UploadFiles(torrent_data=b"torrent", log_files=[("rip.log", b"log")])
+        expected = (123, 456)
 
-    async def fail_site_page_upload(data: dict, files: UploadFiles) -> tuple[int, int]:
-        raise LoginError
+        tracker.site_page_upload = AsyncMock(side_effect=LoginError)  # type: ignore[method-assign]
+        tracker.api_key_upload = AsyncMock(return_value=expected)  # type: ignore[method-assign]
 
-    async def ok_api_upload(data: dict, files: UploadFiles) -> tuple[int, int]:
-        return expected
-
-    monkeypatch.setattr(tracker, "site_page_upload", fail_site_page_upload)
-    monkeypatch.setattr(tracker, "api_key_upload", ok_api_upload)
-
-    assert await tracker.upload({}, files) == expected
+        self.assertEqual(await tracker.upload({}, files), expected)


### PR DESCRIPTION
## Summary
- normalize decoded Gazelle session cookies before sending them
- support optional `keeplogged` companion cookies for RED, OPS, and DIC
- fall back to RED API uploads when `upload.php` auth fails but an API key is configured
- add regression coverage for the cookie normalization and RED upload fallback paths

Closes #361.

## Verification
- `uv run ruff check src/salmon/trackers/base.py src/salmon/trackers/red.py src/salmon/config/validations.py tests/test_trackers_base.py tests/test_trackers_red.py`
- `uv run --with pytest pytest -q tests/test_trackers_base.py tests/test_trackers_red.py`
- `uv run --with basedpyright basedpyright src/salmon/trackers/base.py src/salmon/trackers/red.py tests/test_trackers_base.py tests/test_trackers_red.py`