### PR TITLE
Fix rclone progress output during seedbox uploads

### DIFF
--- a/src/salmon/uploader/seedbox.py
+++ b/src/salmon/uploader/seedbox.py
@@ -44,7 +44,8 @@ async def _rclone_upload_folder(seedbox: Seedbox, remote_folder: str, path: str)
     commands = ["rclone", "copy", path, f"{seedbox.url}:{remote_path}", *seedbox.extra_args]
     click.secho(f"Starting Rclone upload to {seedbox.url}:{remote_folder}", fg="cyan")
     click.secho(f"Executing: {' '.join(commands)}", fg="yellow")
-    result = await anyio.run_process(commands)
+    # Let rclone write directly to the terminal so flags like -P can render live progress output.
+    result = await anyio.run_process(commands, stdout=None, stderr=None, check=False)
     if result.returncode == 0:
         click.secho(f"Rclone upload successful: {path} to {seedbox.url}:{remote_path}", fg="green")
     else:

--- a/tests/test_uploader_seedbox.py
+++ b/tests/test_uploader_seedbox.py
@@ -1,0 +1,52 @@
+import subprocess
+
+import anyio
+
+from salmon.config.validations import Seedbox
+from salmon.uploader import seedbox
+
+
+def test_rclone_upload_folder_streams_progress_output(monkeypatch) -> None:
+    run_process_calls: list[tuple[list[str], dict[str, object]]] = []
+    messages: list[str] = []
+
+    async def fake_run_process(commands: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        run_process_calls.append((commands, kwargs))
+        return subprocess.CompletedProcess(commands, 0)
+
+    monkeypatch.setattr(seedbox.anyio, "run_process", fake_run_process)
+    monkeypatch.setattr(seedbox.click, "secho", lambda message, **kwargs: messages.append(message))
+
+    anyio.run(
+        seedbox._rclone_upload_folder,
+        Seedbox(url="seedbox", extra_args=["--checksum", "-P"]),
+        "/music",
+        "/tmp/Artist - Album",
+    )
+
+    assert run_process_calls == [
+        (
+            ["rclone", "copy", "/tmp/Artist - Album", "seedbox:/music/Artist - Album", "--checksum", "-P"],
+            {"stdout": None, "stderr": None, "check": False},
+        )
+    ]
+    assert any("Rclone upload successful" in message for message in messages)
+
+
+def test_rclone_upload_folder_reports_nonzero_exit_code(monkeypatch) -> None:
+    messages: list[str] = []
+
+    async def fake_run_process(commands: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(commands, 7)
+
+    monkeypatch.setattr(seedbox.anyio, "run_process", fake_run_process)
+    monkeypatch.setattr(seedbox.click, "secho", lambda message, **kwargs: messages.append(message))
+
+    anyio.run(
+        seedbox._rclone_upload_folder,
+        Seedbox(url="seedbox", extra_args=["-P"]),
+        "/music",
+        "/tmp/Artist - Album",
+    )
+
+    assert "Rclone upload failed with exit code 7" in messages


### PR DESCRIPTION
## Summary
- let the rclone seedbox upload subprocess inherit stdout/stderr so `-P` can render live progress
- disable `check=True` on that subprocess path so non-zero exits are reported by the existing return-code handling
- add regression coverage for the streamed-output and non-zero-exit cases

## Testing
- `uv run --with pytest python -m pytest tests/test_uploader_seedbox.py tests/test_tagger_bandcamp.py`
- `uv run ruff check .`
- `uv run --with basedpyright basedpyright`

Closes #354.