### PR TITLE
Fix type error in Beatport scraper

### DIFF
--- a/src/salmon/sources/beatport.py
+++ b/src/salmon/sources/beatport.py
@@ -41,7 +41,7 @@ class BeatportBase(BaseScraper):
             if not script_tag or not script_tag.string:
                 raise ScrapeError("Could not find Next.js data script tag")
 
-            data = msgspec.json.decode(script_tag.string)
+            data = msgspec.json.decode(str(script_tag.string))
             queries = data["props"]["pageProps"]["dehydratedState"]["queries"]
 
             track_query = next((q for q in queries if q.get("queryKey") and q["queryKey"][0] == "tracks"), None)


### PR DESCRIPTION
i was testing for possible cloudflare issues. Found an unrelated bug:

```
  File "[...]src/salmon/sources/beatport.py", line 44, in fetch_data
    data = msgspec.json.decode(script_tag.string)
TypeError: a bytes-like object is required, not 'Script'
```

`script_tag.string` is a [`bs4.Script`](https://www.crummy.com/software/BeautifulSoup/bs4/doc/api/bs4.html#bs4.Script). it is a `str` subclass, but msgspec doesn't like it...

this PR calls `str()` on it, now it works. 🤷‍♀️ 
