### PR TITLE
Fix Qobuz search running when not configured

### DIFF
--- a/src/salmon/search/qobuz.py
+++ b/src/salmon/search/qobuz.py
@@ -12,7 +12,7 @@ from salmon.sources.qobuz import QobuzBase
 
 class Searcher(QobuzBase, SearchMixin):
     async def search_releases(self, searchstr, limit):
-        if not cfg.metadata.qobuz:
+        if not cfg.metadata.qobuz.app_id:
             return "Qobuz", {}
 
         releases = {}


### PR DESCRIPTION
There qobuz errors when searching, even when the qobuz section is removed from the config.

Its checked here:
```py
        if not cfg.metadata.qobuz:
            return "Qobuz", {}
```

But cfg.metadata.qobuz has a default and is never None:
```py
class Metadata(BaseStruct):
    discogs_token: str | None = None
    qobuz: QobuzSettings = msgspec.field(default_factory=QobuzSettings)
```

This PR changes the check to `cfg.metadata.qobuz.app_id`. no more errors ☀️