### PR TITLE
Add optional Beatport API scraping

### DIFF
--- a/src/salmon/common/__init__.py
+++ b/src/salmon/common/__init__.py
@@ -3,7 +3,8 @@ import contextlib
 import platform
 import sys
 import traceback
-from typing import Any
+from collections.abc import Awaitable
+from typing import TypeVar
 
 import aiohttp
 import asyncclick as click
@@ -170,7 +171,10 @@ def _format_scrape_error_message(error: BaseException) -> str:
     return error.__class__.__name__
 
 
-async def handle_scrape_errors(task: Any, mute: bool = False) -> Any | None:
+ReturnType = TypeVar("ReturnType")
+
+
+async def handle_scrape_errors(task: Awaitable[ReturnType], mute: bool = False) -> ReturnType | None:
     """Handle errors during scraping tasks.
 
     Args:

--- a/src/salmon/config/validations.py
+++ b/src/salmon/config/validations.py
@@ -68,11 +68,17 @@ class AppleMusicSettings(BaseStruct):
     storefronts: list[str] = msgspec.field(default_factory=lambda: ["us:en-US", "jp:ja", "cn:zh-Hans-CN"])
 
 
+class BeatportSettings(BaseStruct):
+    username: str | None = None
+    password: str | None = None
+
+
 class Metadata(BaseStruct):
     discogs_token: str | None = None
     qobuz: QobuzSettings = msgspec.field(default_factory=QobuzSettings)
     tidal: TidalSettings = msgspec.field(default_factory=TidalSettings)
     apple_music: AppleMusicSettings = msgspec.field(default_factory=AppleMusicSettings)
+    beatport: BeatportSettings = msgspec.field(default_factory=BeatportSettings)
 
 
 class GazelleTrackerSettings(BaseStruct):

--- a/src/salmon/data/config.default.toml
+++ b/src/salmon/data/config.default.toml
@@ -79,6 +79,10 @@ user_auth_token = 'user_auth_token'
 # if you are using salmon from a non-english country, set this to true to avoid retrieving non-english genres
 # no_genres_from_qobuz = False
 
+# remove if not using beatport
+[metadata.beatport]
+username = 'username'
+password = 'password'
 
 # ===============================
 # TRACKER SETTINGS

--- a/src/salmon/search/beatport.py
+++ b/src/salmon/search/beatport.py
@@ -1,15 +1,56 @@
+import time
 from typing import Any
 
+import asyncclick as click
 import msgspec
 
 from salmon import cfg
+from salmon.common import handle_scrape_errors
 from salmon.errors import ScrapeError
 from salmon.search.base import IdentData, SearchMixin
 from salmon.sources import BeatportBase
+from salmon.sources.beatport import TokenStorage
 
 
 class Searcher(BeatportBase, SearchMixin):
-    async def search_releases(self, searchstr: str, limit: int) -> tuple[str, dict]:
+    async def search_releases_api(self, token_storage: TokenStorage, searchstr: str, limit: int) -> tuple[str, dict]:
+        params = {"q": searchstr, "type": "releases"}
+        resp = await self.get_json("/catalog/search/", params=params, headers=token_storage.get_auth_header())
+
+        releases: dict[Any, Any] = {}
+        for release in resp["releases"]:
+            try:
+                rls_id = release["id"]
+
+                main_artists = [a["name"] for a in release["artists"]]
+                artists = (
+                    ", ".join(main_artists) if len(main_artists) < 4 else cfg.upload.formatting.various_artist_word
+                )
+
+                title = release["name"]
+                year = time.strptime(release["publish_date"], "%Y-%m-%d").tm_year
+                track_count = release["track_count"]
+                explicit = release["is_explicit"]
+
+                label = edition = release["label"]["name"]
+                catno = release["catalog_number"]
+                if catno != release["upc"]:
+                    edition += " " + catno
+
+                if label.lower() not in cfg.upload.search.excluded_labels:
+                    releases[rls_id] = (
+                        IdentData(artists, title, year, track_count, "WEB"),
+                        self.format_result(artists, title, edition, track_count, explicit=explicit),
+                    )
+            except (KeyError, IndexError) as e:
+                raise ScrapeError("Failed to parse search result item") from e
+
+            if len(releases) == limit:
+                break
+
+        return "Beatport", releases
+
+    async def search_releases_scraping(self, searchstr: str, limit: int) -> tuple[str, dict]:
         releases: dict[Any, Any] = {}
         soup = await self.fetch_page(self.search_url, params={"q": searchstr})
         try:
@@ -50,3 +91,16 @@ class Searcher(BeatportBase, SearchMixin):
             raise ScrapeError("Failed to parse scraped search results") from e
 
         return "Beatport", releases
+
+    async def search_releases(self, searchstr: str, limit: int) -> tuple[str, dict]:
+        token_storage = await self.load_token_storage()
+        if token_storage:
+            resp: tuple[str, dict] | None = await handle_scrape_errors(
+                self.search_releases_api(token_storage, searchstr, limit)
+            )
+            if resp:
+                return resp
+            else:
+                click.secho("Beatport API error, falling back to scraper", fg="yellow")
+
+        return await self.search_releases_scraping(searchstr, limit)

--- a/src/salmon/sources/base.py
+++ b/src/salmon/sources/base.py
@@ -55,6 +55,17 @@ class BaseScraper:
         rls_id_str = rls_id[1] if isinstance(rls_id, tuple) else rls_id
         return cls.site_url + cls.release_format.format(rls_id=rls_id_str)
 
+    async def handle_json_response(self, resp: aiohttp.ClientResponse) -> dict:
+        if resp.status != 200:
+            class_hierarchy = " -> ".join([cls.__name__ for cls in self.__class__.mro()[:-1]])
+            error_msg = f"{self.__class__.__name__}({class_hierarchy}): Status code {resp.status}."
+            try:
+                error_data = await resp.text()
+            except Exception:
+                error_data = None
+            raise ScrapeError(error_msg, error_data)
+        return msgspec.json.decode(await resp.read())
+
     async def get_json(self, url: str, params: dict | None = None, headers: dict | None = None) -> dict:
         """Make async GET request to JSON API.
 
@@ -80,15 +91,7 @@ class BaseScraper:
                 aiohttp.ClientSession(timeout=timeout) as session,
                 session.get(full_url, params=params, headers=headers) as resp,
             ):
-                if resp.status != 200:
-                    class_hierarchy = " -> ".join([cls.__name__ for cls in self.__class__.mro()[:-1]])
-                    error_msg = f"{self.__class__.__name__}({class_hierarchy}): Status code {resp.status}."
-                    try:
-                        error_data = await resp.text()
-                    except Exception:
-                        error_data = None
-                    raise ScrapeError(error_msg, error_data)
-                return msgspec.json.decode(await resp.read())
+                return await self.handle_json_response(resp)
         except aiohttp.ContentTypeError as e:
             raise ScrapeError(f"{self.__class__.__name__}: Did not receive JSON from API.") from e
         except msgspec.DecodeError as e:
@@ -145,10 +148,11 @@ class BaseScraper:
         ``NotImplementedError``.
 
         Args:
-            url: The release URL.
-            params: Optional query parameters.
-            headers: Optional HTTP headers.
-            follow_redirects: Whether to follow redirects.
+            :param url: The release URL.
+            :param params: Optional query parameters.
+            :param headers: Optional HTTP headers.
+            :param follow_redirects: Whether to follow redirects.
+            :param rls_id: The Release ID.
 
         Returns:
             Release data dict.

--- a/src/salmon/sources/beatport.py
+++ b/src/salmon/sources/beatport.py
@@ -1,33 +1,225 @@
+import os.path
 import re
+from pathlib import Path
+from time import time
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
+import aiohttp
+import asyncclick as click
 import msgspec
+from aiohttp import ClientSession
+from bs4 import BeautifulSoup
 
+from salmon import cfg
+from salmon.common import handle_scrape_errors
+from salmon.config import get_user_cfg_path
 from salmon.errors import ScrapeError
 from salmon.sources.base import BaseScraper
 
 
+class TokenStorage(msgspec.Struct):
+    """
+    Helper struct, holds auth tokens and takes care of persistence.
+    """
+
+    bearer: str
+    expires: float
+    refresh_token: str
+    client_id: str
+
+    @staticmethod
+    def from_response(json: dict, client_id: str) -> Any:
+        self = TokenStorage(
+            bearer=json["access_token"],
+            expires=time() + json["expires_in"],
+            refresh_token=json["refresh_token"],
+            client_id=client_id,
+        )
+        self._save()
+        return self
+
+    @staticmethod
+    def _get_storage_file() -> Path:
+        return get_user_cfg_path().with_name("beatport_auth.json")
+
+    def _save(self):
+        file = self._get_storage_file()
+        if file.exists():
+            file.touch()
+        file.write_bytes(msgspec.json.encode(self))
+
+    @classmethod
+    def load(cls) -> Any | None:
+        file = TokenStorage._get_storage_file()
+        if os.path.exists(file):
+            try:
+                self = msgspec.json.decode(file.read_bytes(), type=TokenStorage)
+                return self
+            except msgspec.MsgspecError as e:
+                click.secho(f"Error reading token storage: {e}", fg="red")
+        return None
+
+    def get_auth_header(self) -> dict:
+        return {"Authorization": f"Bearer {self.bearer}"}
+
+
 class BeatportBase(BaseScraper):
-    url = site_url = "https://beatport.com"
+    api_domain = "https://api.beatport.com"
+    url = api_domain + "/v4"
+    oauth_redirect_uri = url + "/auth/o/post-message/"
+    site_url = "https://beatport.com"
     search_url = "https://beatport.com/search/releases"
     release_format = "/release/{rls_name}/{rls_id}"
     regex = re.compile(r"^https?://(?:(?:www|classic)\.)?beatport\.com/release/.+?/(\d+)/?$")
 
-    async def fetch_data(
+    is_json_api = True
+
+    async def load_token_storage(self) -> TokenStorage | None:
+        """
+        Loads the TokenStorage from the disk.
+        Refreshes the token if expired.
+        If it doesn't exist, runs the initial setup.
+        :return: TokenStorage containing a valid bearer token, or None if no credentials configured
+        """
+        token_storage = TokenStorage.load() or await self.initial_setup()
+        if token_storage and token_storage.expires < time() + 10:  # leave some wiggle room
+            token_storage = await self.refresh_bearer_token(token_storage)
+        return token_storage
+
+    async def refresh_bearer_token(self, token_storage: TokenStorage) -> TokenStorage:
+        """
+        Refreshes a TokenStorage's bearer token. The new tokens are saved automatically.
+        :param token_storage:
+        :return: new TokenStorage with valid credentials.
+        """
+        click.secho("Refreshing Beatport token", fg="yellow")
+        async with aiohttp.ClientSession() as session:
+            headers = token_storage.get_auth_header()
+            payload = {
+                "client_id": token_storage.client_id,
+                "refresh_token": token_storage.refresh_token,
+                "grant_type": "refresh_token",
+            }
+            resp = await session.post(self.url + "/auth/o/token/", headers=headers, data=payload)
+            json = await self.handle_json_response(resp)
+            return TokenStorage.from_response(json, token_storage.client_id)
+
+    async def _get_client_id(self, session: ClientSession) -> str:
+        """
+        Scrapes the OAuth client ID used by the API docs
+        :param session:
+        :return: The Client ID
+        """
+        soup = await self.fetch_page(self.url + "/docs/")
+        client_id_pattern = re.compile(r"API_CLIENT_ID: \'(.*)\'")
+
+        for script in soup.find_all("script", src=True):
+            url = self.api_domain + str(script.get("src"))
+            resp = await session.get(url)
+            text = await resp.text("utf-8")
+            client_id_matches = client_id_pattern.findall(text)
+            if client_id_matches:
+                return client_id_matches[0]
+        raise Exception("Failed to find beatport client ID")
+
+    async def initial_setup(self) -> TokenStorage | None:
+        """
+        Initial beatport setup. Uses user credentials to acquire a valid TokenStorage, which can be refreshed later.
+        :return: TokenStorage containing valid auth tokens. It is persisted automatically.
+        """
+        username = cfg.metadata.beatport.username
+        password = cfg.metadata.beatport.password
+        if not username or not password:  # Not configured
+            return None
+
+        async with aiohttp.ClientSession() as session:
+            click.secho("Logging into Beatport for the first time", fg="green")
+
+            # Step 1: get client id from the docs. if this ever fails, we want it to fail first
+            click.echo("Fetching Client ID")
+            client_id = await self._get_client_id(session)
+
+            # Step 2: login with username / password to set cookies
+            click.secho("Logging in...")
+            payload = {"username": username, "password": password}
+            resp = await session.post(self.url + "/auth/login/", json=payload)
+            await self.handle_json_response(resp)
+
+            # Step 3: get authorization code from the docs' OAuth request
+            params = {
+                "client_id": client_id,
+                "redirect_uri": self.oauth_redirect_uri,
+                "response_type": "code",
+            }
+            resp = await session.get(self.url + "/auth/o/authorize/", params=params, allow_redirects=False)
+            if resp.status < 300 or resp.status >= 400:
+                data = await resp.read()
+                soup = BeautifulSoup(data, "lxml")
+                error = (soup.find("body") or soup).get_text("\n")
+                raise Exception(f"Error during beatport OAuth flow:\n{error}")
+
+            location = resp.headers.get("location")
+            if not location:
+                raise Exception(
+                    f"Error during beatport OAuth flow: status is {resp.status}, but Location header is missing"
+                )
+            parsed = urlsplit(location)
+            code = parse_qs(parsed.query).get("code")
+            if not code:
+                raise Exception(f"Error during beatport OAuth flow: no authorization code in redirect: {location}")
+
+            # Step 4: finish code grant flow
+            payload = {
+                "client_id": client_id,
+                "code": code,
+                "redirect_uri": self.oauth_redirect_uri,
+                "grant_type": "authorization_code",
+            }
+            resp = await session.post(self.url + "/auth/o/token/", data=payload)
+            json = await self.handle_json_response(resp)
+            token_storage = TokenStorage.from_response(json, client_id)
+
+        click.secho("Done! Salmon will remember this login.", fg="green")
+        return token_storage
+
+    async def fetch_data_api(
+        self, url, token_storage: TokenStorage, params: dict, rls_id: str | None = None
+    ) -> dict[str, Any]:
+        if not rls_id:
+            match = self.regex.match(url)
+            if not match:
+                raise ScrapeError("Invalid Beatport URL format")
+            rls_id = match.group(1)
+
+        params = params or {}
+        release_resp = await self.get_json(
+            f"/catalog/releases/{rls_id}/", params=params, headers=token_storage.get_auth_header()
+        )
+
+        tracks = []
+        params["release_id"] = rls_id
+        params["per_page"] = 100
+
+        for page in range(1, 9999):
+            params["page"] = page
+            resp = await self.get_json("/catalog/tracks/", params=params, headers=token_storage.get_auth_header())
+            tracks.extend(resp["results"])
+            if not resp["next"]:
+                break
+
+        return {"tracks": tracks, "release": release_resp}
+
+    async def fetch_data_scraping(
         self,
         url: str,
-        params: dict | None = None,
-        headers: dict | None = None,
-        follow_redirects: bool = True,
-        rls_id: Any = None,
-    ) -> dict:
+        params: dict | None,
+    ) -> dict[str, Any]:
         """Extract JSON track data from Beatport's HTML page.
 
         Args:
             url: The Beatport URL.
             params: Optional query parameters.
-            headers: Optional HTTP headers.
-            follow_redirects: Whether to follow redirects.
 
         Returns:
             Track query dict extracted from page data.
@@ -45,13 +237,51 @@ class BeatportBase(BaseScraper):
             queries = data["props"]["pageProps"]["dehydratedState"]["queries"]
 
             track_query = next((q for q in queries if q.get("queryKey") and q["queryKey"][0] == "tracks"), None)
-
             if not track_query:
                 raise ScrapeError("Could not find track data in page")
 
-            return track_query
+            release_query_regex = re.compile(r"release-\d+")
+            release_query = next(
+                (q for q in queries if q.get("queryKey") and release_query_regex.match(q["queryKey"][0])), None
+            )
+            if not release_query:
+                raise ScrapeError("Could not find release data in page")
+
+            return {"tracks": track_query["state"]["data"]["results"], "release": release_query["state"]["data"]}
 
         except msgspec.DecodeError as e:
             raise ScrapeError("Failed to parse Beatport JSON data") from e
         except (KeyError, AttributeError) as e:
             raise ScrapeError(f"Failed to extract required data from Beatport page: {e}") from e
+
+    async def fetch_data(
+        self,
+        url: str,
+        params: dict | None = None,
+        headers: dict | None = None,
+        follow_redirects: bool = True,
+        rls_id: Any = None,
+    ) -> dict:
+        """
+        Fetches JSON track data:
+        - from the official API, if configured
+        - fallback to the internal API, by scraping the page
+
+        :param url: The Beatport URL.
+        :param params: Optional query parameters.
+        :param headers: Inherited, ignored.
+        :param follow_redirects: Inherited, ignored.
+        :param rls_id: skips parsing ID from the URL; ignored when scraping.
+        :return:
+        """
+        params_dict: dict = params or {}
+
+        token_storage = await self.load_token_storage()
+        if token_storage:
+            resp = await handle_scrape_errors(self.fetch_data_api(url, token_storage, params_dict, rls_id=rls_id))
+            if resp:
+                return resp
+            else:
+                click.secho("Beatport API error, falling back to scraper", fg="yellow")
+
+        return await self.fetch_data_scraping(url, params_dict)

--- a/src/salmon/tagger/sources/beatport.py
+++ b/src/salmon/tagger/sources/beatport.py
@@ -24,21 +24,20 @@ SPLIT_GENRES = {
 class Scraper(BeatportBase, MetadataMixin):
     def parse_release_title(self, soup):
         try:
-            return soup["state"]["data"]["results"][0]["release"]["name"]
+            return soup["release"]["name"]
         except (KeyError, IndexError) as e:
             raise ScrapeError("Could not parse release title") from e
 
     def parse_cover_url(self, soup):
         try:
-            return soup["state"]["data"]["results"][0]["release"]["image"]["uri"]
+            return soup["release"]["image"]["uri"]
         except (KeyError, IndexError) as e:
             raise ScrapeError("Could not parse cover URL") from e
 
     def parse_genres(self, soup):
         genres = {"Electronic"}
         try:
-            tracks = soup["state"]["data"]["results"]
-            for track in tracks:
+            for track in soup["tracks"]:
                 genre_name = track["genre"]["name"]
                 try:
                     genres |= SPLIT_GENRES[genre_name]
@@ -60,32 +59,36 @@ class Scraper(BeatportBase, MetadataMixin):
 
     def parse_release_date(self, soup):
         try:
-            return soup["state"]["data"]["results"][0]["new_release_date"]
+            return soup["release"]["new_release_date"]
         except (KeyError, IndexError) as e:
             raise ScrapeError("Could not parse release date") from e
 
     def parse_release_label(self, soup):
         try:
-            return soup["state"]["data"]["results"][0]["release"]["label"]["name"]
+            return soup["release"]["label"]["name"]
         except (KeyError, IndexError) as e:
             raise ScrapeError("Could not parse release label") from e
 
     def parse_release_catno(self, soup):
         try:
-            return soup["state"]["data"]["results"][0]["catalog_number"]
+            return soup["release"]["catalog_number"]
         except (KeyError, IndexError) as e:
             raise ScrapeError("Could not parse catalog number") from e
 
     def parse_comment(self, soup):
         return None
 
+    def parse_upc(self, soup):
+        try:
+            return soup["release"]["upc"]
+        except (KeyError, IndexError) as e:
+            raise ScrapeError("Could not parse UPC") from e
+
     async def parse_tracks(self, soup):
         tracks = defaultdict(dict)
         cur_disc = 1
         try:
-            track_list = sorted(
-                soup["state"]["data"]["results"], key=lambda x: int(x["id"]) if x["id"] is not None else 0
-            )
+            track_list = sorted(soup["tracks"], key=lambda x: int(x["id"]) if x["id"] is not None else 0)
             for i, track in enumerate(track_list, 1):
                 track_num = str(i)
                 # Get artists and remixers


### PR DESCRIPTION
closes #364 

- new optional beatport config fields
- the first time they are set, salmon will perform the OAuth flow (`BeatportBase.initial_setup`)
- the tokens are saved in a json file (see `TokenStorage). while the file exists, tokens can be refreshed and reused.
- TODO: what if they become invalid? try the initial setup again?
- if tokens can be acquired, salmon will use the API for search, releases & tracks
- if the API call fails, or no credentials exist, the existing scraping method is used
- the scraping method now returns the same data as the API, including releases
- changed some adjacent type hints & docs 