### PR TITLE
Fix serialization error when discogs token is missing

### DIFF
--- a/src/salmon/sources/base.py
+++ b/src/salmon/sources/base.py
@@ -83,6 +83,7 @@ class BaseScraper:
             ScrapeError: If request fails or response is not JSON.
         """
         params = {**(params or {}), **(self.get_params or {})}
+        params = {k: v for k, v in params.items() if v is not None}  # remove None values before serializing
         headers = {**(headers or {}), **HEADERS}
         full_url = url if url.startswith(("http://", "https://")) else self.url + url
         timeout = aiohttp.ClientTimeout(total=10)


### PR DESCRIPTION
when no discogs token is defined, this happens:
```
Unexpected scrape error: Invalid variable type: value should be str, int or float, got None of type <class 'NoneType'>
Traceback (most recent call last):
  File "./smoked-salmon/src/salmon/common/__init__.py", line 188, in handle_scrape_errors
    return await task
           ^^^^^^^^^^
  File "./smoked-salmon/src/salmon/search/discogs.py", line 18, in search_releases
    resp = await self.get_json(
           ^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
    )
    ^
  File "./smoked-salmon/src/salmon/sources/base.py", line 93, in get_json
    session.get(full_url, params=params, headers=headers) as resp,
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./smoked-salmon/.venv/Lib/site-packages/aiohttp/client.py", line 1521, in __aenter__
    self._resp: _RetType = await self._coro
                           ^^^^^^^^^^^^^^^^
  File "./smoked-salmon/.venv/Lib/site-packages/aiohttp/client.py", line 710, in _request
    req = self._request_class(
        method,
    ...<21 lines>...
        trust_env=self.trust_env,
    )
  File "./smoked-salmon/.venv/Lib/site-packages/aiohttp/client_reqrep.py", line 873, in __init__
    url = url.extend_query(params)
  File "./smoked-salmon/.venv/Lib/site-packages/yarl/_url.py", line 1225, in extend_query
    if not (new_query := get_str_query(*args, **kwargs)):
                         ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "./smoked-salmon/.venv/Lib/site-packages/yarl/_query.py", line 102, in get_str_query
    return get_str_query_from_sequence_iterable(query.items())
  File "./smoked-salmon/.venv/Lib/site-packages/yarl/_query.py", line 51, in get_str_query_from_sequence_iterable
    f"{quoter(k)}={quoter(v if type(v) is str else query_var(v))}"
                                                   ~~~~~~~~~^^^
  File "./smoked-salmon/.venv/Lib/site-packages/yarl/_query.py", line 33, in query_var
    raise TypeError(
    ...<3 lines>...
    )
TypeError: Invalid variable type: value should be str, int or float, got None of type <class 'NoneType'>
```

this PR filters the request params to remove None values 🌼