### PR TITLE
Fix beatport scraper splitting artist names

### DIFF
--- a/src/salmon/tagger/sources/beatport.py
+++ b/src/salmon/tagger/sources/beatport.py
@@ -94,11 +94,9 @@ class Scraper(BeatportBase, MetadataMixin):
                 # Get artists and remixers
                 artists = []
                 for artist in track["artists"]:
-                    for split in re.split(" & |; | / ", artist["name"]):
-                        artists.append((split, "main"))
+                    artists.append((artist["name"], "main"))
                 for remixer in track["remixers"]:
-                    for split in re.split(" & |; | / ", remixer["name"]):
-                        artists.append((split, "remixer"))
+                    artists.append((remixer["name"], "remixer"))
 
                 # Get title with mix name if not Original Mix
                 title = track["name"]


### PR DESCRIPTION
beatport lists artists separately. the splitting is a leftover from the original salmon

before:
```
$ salmon meta https://www.beatport.com/release/blue-monday/2823990 
...
{'artists': [('Above', 'main'), ('Beyond', 'main')],
```

after:
```
$ salmon meta https://www.beatport.com/release/blue-monday/2823990 
...
{'artists': [('Above & Beyond', 'main')],
```

