### PR TITLE
Prevent missing tracks by fixing track ordering in combine_tracks()

### DIFF
--- a/src/salmon/tagger/combine.py
+++ b/src/salmon/tagger/combine.py
@@ -179,10 +179,23 @@ def _extract_remixers_from_title(title):
     return []
 
 
+def _natural_track_key(value):
+    """Sort keys numerically while still handling mixed values like A1/B2."""
+    return tuple(
+        (0, int(part)) if part.isdigit() else (1, part.lower()) for part in re.split(r"(\d+)", str(value)) if part
+    )
+
+
+def _sorted_naturally(items):
+    return sorted(items, key=lambda item: _natural_track_key(item[0]))
+
+
 def combine_tracks(base, meta, update_track_numbers):
     """Combine the metadata for the tracks of two different sources."""
-    # btracks could be sorted by filename, so sort by track# if possible
-    btracks_sorted = [[track for (no, track) in sorted(disc.items())] for disc in base.values()]
+    # Track dictionaries reflect discovery order, so sort discs and tracks naturally before pairing.
+    btracks_sorted = [
+        [track for _, track in _sorted_naturally(disc.items())] for _, disc in _sorted_naturally(base.items())
+    ]
     btracks = iter(chain.from_iterable(btracks_sorted))
 
     # If the source already provides remixer credits, skip title-based inference
@@ -191,8 +204,8 @@ def combine_tracks(base, meta, update_track_numbers):
         role == "remixer" for tracks in meta.values() for track in tracks.values() for _, role in track["artists"]
     )
 
-    for disc, tracks in meta.items():
-        for num, track in tracks.items():
+    for disc, tracks in _sorted_naturally(meta.items()):
+        for num, track in _sorted_naturally(tracks.items()):
             try:
                 btrack = next(btracks)
             except StopIteration:

--- a/tests/test_tagger_combine.py
+++ b/tests/test_tagger_combine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from salmon.tagger.combine import combine_metadatas
+from salmon.tagger.combine import combine_metadatas, combine_tracks
 
 
 def make_metadata(title: str) -> dict:
@@ -49,6 +49,29 @@ def make_metadata(title: str) -> dict:
     }
 
 
+def make_tracks(discs: dict[str, list[str]], *, isrc_prefix: str | None) -> dict:
+    return {
+        disc_no: {
+            track_no: {
+                "track#": track_no,
+                "disc#": disc_no,
+                "tracktotal": str(len(track_nos)),
+                "disctotal": str(len(discs)),
+                "artists": [("Marius Acke", "main")],
+                "title": f"Track {disc_no}-{track_no}",
+                "replay_gain": None,
+                "peak": None,
+                "isrc": f"{isrc_prefix} {disc_no}-{track_no}" if isrc_prefix is not None else None,
+                "explicit": None,
+                "format": None,
+                "streamable": None,
+            }
+            for track_no in track_nos
+        }
+        for disc_no, track_nos in discs.items()
+    }
+
+
 def test_preferred_source_title_overrides_stale_local_album_title():
     base = make_metadata("TOW014 / Marius Acke - Dirty & Funky EP")
     preferred = make_metadata("Dirty & Funky EP")
@@ -62,3 +85,31 @@ def test_preferred_source_title_overrides_stale_local_album_title():
     )
 
     assert combined["title"] == "Dirty & Funky EP"
+
+
+def test_combine_tracks_keeps_all_tracks_when_updating_track_numbers():
+    ordered_tracks = [str(i) for i in range(1, 12)]
+    base = make_tracks({"1": ["1", "10", "11", "2", "3", "4", "5", "6", "7", "8", "9"]}, isrc_prefix=None)
+    meta = make_tracks({"1": ordered_tracks}, isrc_prefix="ISRC")
+
+    combined = combine_tracks(deepcopy(base), deepcopy(meta), True)
+
+    assert list(combined["1"].keys()) == ordered_tracks
+    assert len(combined["1"]) == 11
+    assert [combined["1"][str(i)]["isrc"] for i in range(1, 12)] == [f"ISRC 1-{i}" for i in range(1, 12)]
+
+
+def test_combine_tracks_sorts_multi_disc_provider_tracks_and_discs():
+    base = make_tracks({"2": ["1", "2", "10"], "1": ["1", "2", "10"]}, isrc_prefix=None)
+    meta = make_tracks({"2": ["1", "10", "2"], "1": ["1", "10", "2"]}, isrc_prefix="ISRC")
+
+    combined = combine_tracks(deepcopy(base), deepcopy(meta), True)
+
+    assert list(combined["1"].keys()) == ["1", "2", "10"]
+    assert list(combined["2"].keys()) == ["1", "2", "10"]
+    assert combined["1"]["1"]["isrc"] == "ISRC 1-1"
+    assert combined["1"]["2"]["isrc"] == "ISRC 1-2"
+    assert combined["1"]["10"]["isrc"] == "ISRC 1-10"
+    assert combined["2"]["1"]["isrc"] == "ISRC 2-1"
+    assert combined["2"]["2"]["isrc"] == "ISRC 2-2"
+    assert combined["2"]["10"]["isrc"] == "ISRC 2-10"


### PR DESCRIPTION
this should fix the issue introduced in https://github.com/smokin-salmon/smoked-salmon/commit/d84a570dd5bf93e466c3026cb04d69c9908e8dfa.
this should hopefully close https://github.com/smokin-salmon/smoked-salmon/issues/396?

scope: this only fixes the sorting logic in combine_tracks() & adds regression tests for that behaviour.
it does not address the downstream ordering issues mentioned here: https://github.com/smokin-salmon/smoked-salmon/pull/394

disclosure: both commits were created with ai assistance.
