### PR TITLE
Adds opt-in proxy routing via aiohttp-socks for all network services in salmon.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "aiohttp>=3.8.5 ; sys_platform == 'win32'",
     "aiohttp-jinja2>=1.5.1",
     "aiohttp[speedups]>=3.13.5 ; sys_platform != 'win32'",
+    "aiohttp-socks>=0.11.0",
     "aiolimiter>=1.2.1",
     "anyio>=4.12.1",
     "asyncclick>=8.1.7.2",

--- a/src/salmon/config/validations.py
+++ b/src/salmon/config/validations.py
@@ -245,6 +245,31 @@ class Upload(BaseStruct):
     ai_review: UploadAiReview = msgspec.field(default_factory=UploadAiReview)
 
 
+class ProxyServicesCfg(BaseStruct):
+    """Per-service proxy overrides. None = inherit global; empty string = no proxy."""
+
+    red: str | None = None
+    ops: str | None = None
+    dic: str | None = None
+    qobuz: str | None = None
+    tidal: str | None = None
+    bandcamp: str | None = None
+    deezer: str | None = None
+    beatport: str | None = None
+    discogs: str | None = None
+    apple_music: str | None = None
+    ptpimg: str | None = None
+    ptscreens: str | None = None
+    oeimg: str | None = None
+    imgbb: str | None = None
+    catbox: str | None = None
+
+
+class ProxyCfg(BaseStruct):
+    url: str | None = None
+    services: ProxyServicesCfg = msgspec.field(default_factory=ProxyServicesCfg)
+
+
 class Cfg(BaseStruct):
     "This class defines the schema that msgspec uses to parse the config"
 
@@ -254,3 +279,4 @@ class Cfg(BaseStruct):
     tracker: Tracker = msgspec.field(default_factory=Tracker)
     seedbox: list[Seedbox] = msgspec.field(default_factory=list)
     upload: Upload = msgspec.field(default_factory=Upload)
+    proxy: ProxyCfg = msgspec.field(default_factory=ProxyCfg)

--- a/src/salmon/data/config.default.toml
+++ b/src/salmon/data/config.default.toml
@@ -234,3 +234,43 @@ session = 'get-from-site-cookie'
 # # Increase this for slower reviews, especially with high/xhigh reasoning and web search.
 # timeout_seconds = 45
 # background = false
+
+# ===============================
+# PROXY SETTINGS
+# ===============================
+# # Supports HTTP, HTTPS, SOCKS4, SOCKS4A, SOCKS5. Auth is embedded in the URL.
+# # Format: scheme://[user:pass@]host:port
+# #
+# # To proxy only one service (e.g. qobuz):
+# #   [proxy.services]
+# #   qobuz = "https://host:port"
+# #
+# # To proxy everything:
+# #   [proxy]
+# #   url = "socks4://host:port"
+# #
+# # To proxy everything except one service (empty string disables):
+# #   [proxy]
+# #   url = "socks5://host:port"
+# #   [proxy.services]
+# #   bandcamp = ""
+
+# [proxy]
+# url = ""
+
+# [proxy.services]
+# red         = ""
+# ops         = ""
+# dic         = ""
+# qobuz       = ""
+# tidal       = ""
+# bandcamp    = ""
+# deezer      = ""
+# beatport    = ""
+# discogs     = ""
+# apple_music = ""
+# ptpimg      = ""
+# ptscreens   = ""
+# oeimg       = ""
+# imgbb       = ""
+# catbox      = ""

--- a/src/salmon/images/base.py
+++ b/src/salmon/images/base.py
@@ -9,6 +9,8 @@ class BaseImageUploader:
     Subclasses should implement the async upload_file method.
     """
 
+    proxy_service: str = ""  # Set in subclasses to enable proxy routing
+
     async def upload_file(self, filename: str) -> tuple[str, str | None]:
         """Upload an image file and return the URL.
 

--- a/src/salmon/images/catbox.py
+++ b/src/salmon/images/catbox.py
@@ -7,6 +7,7 @@ import anyio
 from salmon.constants import UAGENTS
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
+from salmon.proxy import session_kwargs
 
 HEADERS = {
     "User-Agent": choice(UAGENTS),
@@ -15,6 +16,8 @@ HEADERS = {
 
 
 class ImageUploader(BaseImageUploader):
+    proxy_service = "catbox"
+
     async def upload_file(self, filename: str) -> tuple[str, None]:
         """Upload image file to catbox.moe.
 
@@ -35,7 +38,7 @@ class ImageUploader(BaseImageUploader):
         data.add_field("fileToUpload", file_data, filename=Path(filename).name)
         url = "https://catbox.moe/user/api.php"
         try:
-            async with aiohttp.ClientSession() as session, session.post(url, headers=HEADERS, data=data) as resp:
+            async with aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session, session.post(url, headers=HEADERS, data=data) as resp:
                 resp.raise_for_status()
                 return await resp.text(), None
         except ValueError as e:

--- a/src/salmon/images/catbox.py
+++ b/src/salmon/images/catbox.py
@@ -38,7 +38,10 @@ class ImageUploader(BaseImageUploader):
         data.add_field("fileToUpload", file_data, filename=Path(filename).name)
         url = "https://catbox.moe/user/api.php"
         try:
-            async with aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session, session.post(url, headers=HEADERS, data=data) as resp:
+            async with (
+                aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session,
+                session.post(url, headers=HEADERS, data=data) as resp,
+            ):
                 resp.raise_for_status()
                 return await resp.text(), None
         except ValueError as e:

--- a/src/salmon/images/imgbb.py
+++ b/src/salmon/images/imgbb.py
@@ -7,12 +7,15 @@ import msgspec
 from salmon import cfg
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
+from salmon.proxy import session_kwargs
 
 HEADERS = {"referer": "https://imgbb.com/", "User-Agent": cfg.upload.user_agent}
 
 
 class ImageUploader(BaseImageUploader):
     """Image uploader for imgbb.com."""
+
+    proxy_service = "imgbb"
 
     async def upload_file(self, filename: str) -> tuple[str, None]:
         """Upload image file to imgbb.com.
@@ -36,7 +39,7 @@ class ImageUploader(BaseImageUploader):
         url = "https://api.imgbb.com/1/upload"
         try:
             async with (
-                aiohttp.ClientSession() as session,
+                aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session,
                 session.post(url, headers=HEADERS, data=data) as resp,
             ):
                 resp.raise_for_status()

--- a/src/salmon/images/oeimg.py
+++ b/src/salmon/images/oeimg.py
@@ -7,12 +7,15 @@ import msgspec
 from salmon import cfg
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
+from salmon.proxy import session_kwargs
 
 HEADERS: dict[str, str] = {"X-API-Key": cfg.image.oeimg_key or ""}
 
 
 class ImageUploader(BaseImageUploader):
     """Image uploader for imgoe.download (oeimg)."""
+
+    proxy_service = "oeimg"
 
     async def upload_file(self, filename: str) -> tuple[str, None]:
         """Upload image file to oeimg.
@@ -35,7 +38,7 @@ class ImageUploader(BaseImageUploader):
         url = "https://imgoe.download/api/1/upload"
         try:
             async with (
-                aiohttp.ClientSession() as session,
+                aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session,
                 session.post(url, headers=HEADERS, data=data) as resp,
             ):
                 resp.raise_for_status()

--- a/src/salmon/images/ptpimg.py
+++ b/src/salmon/images/ptpimg.py
@@ -7,6 +7,7 @@ import msgspec
 from salmon import cfg
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
+from salmon.proxy import session_kwargs
 
 HEADERS = {
     "referer": "https://ptpimg.me/index.php",
@@ -16,6 +17,8 @@ HEADERS = {
 
 class ImageUploader(BaseImageUploader):
     """Image uploader for ptpimg.me."""
+
+    proxy_service = "ptpimg"
 
     async def upload_file(self, filename: str) -> tuple[str, None]:
         """Upload image file to ptpimg.me.
@@ -39,7 +42,7 @@ class ImageUploader(BaseImageUploader):
         url = "https://ptpimg.me/upload.php"
         try:
             async with (
-                aiohttp.ClientSession() as session,
+                aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session,
                 session.post(url, headers=HEADERS, data=data) as resp,
             ):
                 resp.raise_for_status()

--- a/src/salmon/images/ptscreens.py
+++ b/src/salmon/images/ptscreens.py
@@ -7,12 +7,15 @@ import msgspec
 from salmon import cfg
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
+from salmon.proxy import session_kwargs
 
 HEADERS: dict[str, str] = {"X-API-Key": cfg.image.ptscreens_key or ""}
 
 
 class ImageUploader(BaseImageUploader):
     """Image uploader for ptscreens.com."""
+
+    proxy_service = "ptscreens"
 
     async def upload_file(self, filename: str) -> tuple[str, None]:
         """Upload image file to ptscreens.com.
@@ -35,7 +38,7 @@ class ImageUploader(BaseImageUploader):
         url = "https://ptscreens.com/api/1/upload"
         try:
             async with (
-                aiohttp.ClientSession() as session,
+                aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session,
                 session.post(url, headers=HEADERS, data=data) as resp,
             ):
                 resp.raise_for_status()

--- a/src/salmon/proxy.py
+++ b/src/salmon/proxy.py
@@ -17,10 +17,9 @@ def get_connector(service: str) -> BaseConnector | None:
     from salmon import cfg
 
     service_proxy = getattr(cfg.proxy.services, service, None)
-    if service_proxy is not None:
-        proxy_url = service_proxy or None  # empty string → explicitly disabled
-    else:
-        proxy_url = cfg.proxy.url or None
+    proxy_url = (
+        service_proxy or None if service_proxy is not None else cfg.proxy.url or None
+    )
 
     if not proxy_url:
         return None

--- a/src/salmon/proxy.py
+++ b/src/salmon/proxy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aiohttp import BaseConnector
+
+
+def get_connector(service: str) -> BaseConnector | None:
+    """Return an aiohttp connector configured for the proxy of *service*, or None.
+
+    Resolution order:
+      1. cfg.proxy.services.<service>  – explicitly set (empty string → no proxy)
+      2. cfg.proxy.url                 – global fallback
+      3. None                          – direct connection
+    """
+    from salmon import cfg
+
+    service_proxy = getattr(cfg.proxy.services, service, None)
+    if service_proxy is not None:
+        proxy_url = service_proxy or None  # empty string → explicitly disabled
+    else:
+        proxy_url = cfg.proxy.url or None
+
+    if not proxy_url:
+        return None
+
+    from aiohttp_socks import ProxyConnector
+
+    return ProxyConnector.from_url(proxy_url)
+
+
+def session_kwargs(service: str) -> dict[str, Any]:
+    """Return keyword args for aiohttp.ClientSession to route *service* through its proxy."""
+    connector = get_connector(service)
+    return {"connector": connector} if connector is not None else {}

--- a/src/salmon/sources/apple_music.py
+++ b/src/salmon/sources/apple_music.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import aiohttp
 
 from salmon.errors import ScrapeError
+from salmon.proxy import session_kwargs
 
 from .base import BaseScraper
 
@@ -13,6 +14,7 @@ APPLE_MUSIC_URL = "https://music.apple.com"
 
 
 class AppleMusicBase(BaseScraper):
+    proxy_service = "apple_music"
     url = AMP_API_URL
     site_url = APPLE_MUSIC_URL
     search_url = "https://itunes.apple.com/search"
@@ -53,7 +55,7 @@ class AppleMusicBase(BaseScraper):
 
         timeout = aiohttp.ClientTimeout(total=15)
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with aiohttp.ClientSession(timeout=timeout, **session_kwargs(cls.proxy_service)) as session:
                 async with session.get(APPLE_MUSIC_URL, allow_redirects=True) as resp:
                     if resp.status != 200:
                         raise ScrapeError("Failed to load Apple Music homepage")

--- a/src/salmon/sources/bandcamp.py
+++ b/src/salmon/sources/bandcamp.py
@@ -5,6 +5,7 @@ from salmon.sources.base import BaseScraper
 
 
 class BandcampBase(BaseScraper):
+    proxy_service = "bandcamp"
     is_json_api = False
     search_url = "https://bandcamp.com/search/"
     regex = re.compile(r"^https?://([^/]+)/(album|track)/([^/]+)/?")

--- a/src/salmon/sources/base.py
+++ b/src/salmon/sources/base.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 
 from salmon.constants import UAGENTS
 from salmon.errors import ScrapeError
+from salmon.proxy import session_kwargs
 
 HEADERS = {"User-Agent": choice(UAGENTS)}
 
@@ -32,6 +33,7 @@ class BaseScraper:
     release_format: str = ""
     get_params: dict[str, Any] | None = None
     is_json_api: bool = True
+    proxy_service: str = ""  # Set in subclasses to enable proxy routing
 
     @classmethod
     def format_url(cls, rls_id: Any, rls_name: str | None = None, url: str | None = None) -> str:
@@ -89,7 +91,7 @@ class BaseScraper:
         timeout = aiohttp.ClientTimeout(total=10)
         try:
             async with (
-                aiohttp.ClientSession(timeout=timeout) as session,
+                aiohttp.ClientSession(timeout=timeout, **session_kwargs(self.proxy_service)) as session,
                 session.get(full_url, params=params, headers=headers) as resp,
             ):
                 return await self.handle_json_response(resp)
@@ -119,7 +121,7 @@ class BaseScraper:
         timeout = aiohttp.ClientTimeout(total=7)
         try:
             async with (
-                aiohttp.ClientSession(timeout=timeout) as session,
+                aiohttp.ClientSession(timeout=timeout, **session_kwargs(self.proxy_service)) as session,
                 session.get(
                     url,
                     params=params,

--- a/src/salmon/sources/beatport.py
+++ b/src/salmon/sources/beatport.py
@@ -15,6 +15,7 @@ from salmon import cfg
 from salmon.common import handle_scrape_errors
 from salmon.config import get_user_cfg_path
 from salmon.errors import ScrapeError
+from salmon.proxy import session_kwargs
 from salmon.sources.base import BaseScraper
 
 
@@ -65,6 +66,7 @@ class TokenStorage(msgspec.Struct):
 
 
 class BeatportBase(BaseScraper):
+    proxy_service = "beatport"
     api_domain = "https://api.beatport.com"
     url = api_domain + "/v4"
     oauth_redirect_uri = url + "/auth/o/post-message/"
@@ -94,7 +96,7 @@ class BeatportBase(BaseScraper):
         :return: new TokenStorage with valid credentials.
         """
         click.secho("Refreshing Beatport token", fg="yellow")
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session:
             headers = token_storage.get_auth_header()
             payload = {
                 "client_id": token_storage.client_id,
@@ -133,7 +135,7 @@ class BeatportBase(BaseScraper):
         if not username or not password:  # Not configured
             return None
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(**session_kwargs(self.proxy_service)) as session:
             click.secho("Logging into Beatport for the first time", fg="green")
 
             # Step 1: get client id from the docs. if this ever fails, we want it to fail first

--- a/src/salmon/sources/deezer.py
+++ b/src/salmon/sources/deezer.py
@@ -7,6 +7,7 @@ import msgspec
 
 from salmon.constants import UAGENTS
 from salmon.errors import ScrapeError
+from salmon.proxy import session_kwargs
 from salmon.sources.base import BaseScraper
 
 HEADERS = {
@@ -22,6 +23,7 @@ HEADERS = {
 class DeezerBase(BaseScraper):
     """Base scraper for Deezer metadata."""
 
+    proxy_service = "deezer"
     url = "https://api.deezer.com"
     site_url = "https://www.deezer.com"
     regex = re.compile(r"^https*:\/\/.*?deezer\.com.*?\/(?:[a-z]+\/)?(album|playlist|track)\/([0-9]+)")
@@ -47,7 +49,7 @@ class DeezerBase(BaseScraper):
         timeout = aiohttp.ClientTimeout(total=10)
         try:
             async with (
-                aiohttp.ClientSession(timeout=timeout) as session,
+                aiohttp.ClientSession(timeout=timeout, **session_kwargs(self.proxy_service)) as session,
                 session.get(
                     "https://www.deezer.com/ajax/gw-light.php",
                     params=params,
@@ -131,7 +133,7 @@ class DeezerBase(BaseScraper):
         timeout = aiohttp.ClientTimeout(total=10)
         try:
             async with (
-                aiohttp.ClientSession(timeout=timeout) as session,
+                aiohttp.ClientSession(timeout=timeout, **session_kwargs(self.proxy_service)) as session,
                 session.get(self.site_url + url, params=(params or {}), headers=HEADERS) as response,
             ):
                 if response.status != 200:

--- a/src/salmon/sources/discogs.py
+++ b/src/salmon/sources/discogs.py
@@ -9,6 +9,7 @@ from salmon.sources.base import BaseScraper
 
 
 class DiscogsBase(BaseScraper):
+    proxy_service = "discogs"
     url = "https://api.discogs.com"
     site_url = "https://www.discogs.com"
     regex = re.compile(r"^https?://(?:www\.)?discogs\.com/(?:.+?/)?release/(\d+)")

--- a/src/salmon/sources/qobuz.py
+++ b/src/salmon/sources/qobuz.py
@@ -9,6 +9,7 @@ from salmon.sources.base import BaseScraper
 
 
 class QobuzBase(BaseScraper):
+    proxy_service = "qobuz"
     url = "https://www.qobuz.com/api.json/0.2"
     site_url = "https://www.qobuz.com"
     regex = re.compile(

--- a/src/salmon/sources/tidal.py
+++ b/src/salmon/sources/tidal.py
@@ -9,6 +9,7 @@ from salmon.sources.base import BaseScraper
 
 
 class TidalBase(BaseScraper):
+    proxy_service = "tidal"
     url = "https://api.tidalhifi.com/v1"
     site_url = "https://listen.tidal.com"
     image_url = "https://resources.tidal.com/images/{album_id}/1280x1280.jpg"

--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -17,6 +17,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fi
 from salmon import cfg
 from salmon.common import UploadFiles
 from salmon.constants import RELEASE_TYPES
+from salmon.proxy import session_kwargs
 from salmon.errors import (
     LoginError,
     RequestError,
@@ -152,6 +153,7 @@ class BaseGazelleApi:
     site_code: str
     site_string: str
     api_key: str = ""  # Optional, only for API key upload
+    proxy_service: str = ""  # Set in subclasses to enable proxy routing
 
     # Rate limiter: 5 requests per 10 seconds (shared across all instances)
     _rate_limiter = AsyncLimiter(5, 10)
@@ -249,7 +251,7 @@ class BaseGazelleApi:
             timeout = aiohttp.ClientTimeout(total=timeout_secs)
             async with (
                 self._rate_limiter,
-                aiohttp.ClientSession(timeout=timeout, cookies=cookies, headers=headers) as session,
+                aiohttp.ClientSession(timeout=timeout, cookies=cookies, headers=headers, **session_kwargs(self.proxy_service)) as session,
                 session.request(method, url, params=params, data=data) as resp,
             ):
                 text = await resp.text()

--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -17,12 +17,12 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fi
 from salmon import cfg
 from salmon.common import UploadFiles
 from salmon.constants import RELEASE_TYPES
-from salmon.proxy import session_kwargs
 from salmon.errors import (
     LoginError,
     RequestError,
     RequestFailedError,
 )
+from salmon.proxy import session_kwargs
 
 ARTIST_TYPES = [
     "main",
@@ -239,7 +239,10 @@ class BaseGazelleApi:
             await self.ensure_authenticated()
 
         use_api_key = prefer_api_key and bool(self.api_key)
-        headers = {**self.headers, **({"Authorization": self.api_key} if use_api_key else {})}
+        headers = {
+            **self.headers,
+            **({"Authorization": self.api_key} if use_api_key else {}),
+        }
         cookies = {} if use_api_key else self._get_cookies()
 
         if cfg.upload.debug_tracker_connection:
@@ -251,7 +254,12 @@ class BaseGazelleApi:
             timeout = aiohttp.ClientTimeout(total=timeout_secs)
             async with (
                 self._rate_limiter,
-                aiohttp.ClientSession(timeout=timeout, cookies=cookies, headers=headers, **session_kwargs(self.proxy_service)) as session,
+                aiohttp.ClientSession(
+                    timeout=timeout,
+                    cookies=cookies,
+                    headers=headers,
+                    **session_kwargs(self.proxy_service),
+                ) as session,
                 session.request(method, url, params=params, data=data) as resp,
             ):
                 text = await resp.text()

--- a/src/salmon/trackers/dic.py
+++ b/src/salmon/trackers/dic.py
@@ -6,6 +6,8 @@ from salmon.trackers.base import BaseGazelleApi
 
 
 class DICApi(BaseGazelleApi):
+    proxy_service = "dic"
+
     def __init__(self):
         self.site_code = "DIC"
         self.base_url = "https://dicmusic.com"

--- a/src/salmon/trackers/ops.py
+++ b/src/salmon/trackers/ops.py
@@ -13,6 +13,8 @@ from salmon.trackers.base import BaseGazelleApi
 
 
 class OpsApi(BaseGazelleApi):
+    proxy_service = "ops"
+
     def __init__(self):
         self.site_code = "OPS"
         self.base_url = "https://orpheus.network"

--- a/src/salmon/trackers/red.py
+++ b/src/salmon/trackers/red.py
@@ -106,6 +106,8 @@ def _parse_upload_form(data: dict, soup: BeautifulSoup) -> None:
 
 
 class RedApi(BaseGazelleApi):
+    proxy_service = "red"
+
     def __init__(self):
         self.site_code = "RED"
         self.base_url = "https://redacted.sh"

--- a/uv.lock
+++ b/uv.lock
@@ -153,6 +153,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-socks"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "python-socks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
+]
+
+[[package]]
 name = "aiolimiter"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1842,6 +1855,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
+]
+
+[[package]]
 name = "qbittorrent-api"
 version = "2025.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1903,6 +1925,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp", extra = ["speedups"], marker = "sys_platform != 'win32'" },
     { name = "aiohttp-jinja2" },
+    { name = "aiohttp-socks" },
     { name = "aiolimiter" },
     { name = "anyio" },
     { name = "asyncclick" },
@@ -1943,6 +1966,7 @@ requires-dist = [
     { name = "aiohttp", marker = "sys_platform == 'win32'", specifier = ">=3.8.5" },
     { name = "aiohttp", extras = ["speedups"], marker = "sys_platform != 'win32'", specifier = ">=3.13.5" },
     { name = "aiohttp-jinja2", specifier = ">=1.5.1" },
+    { name = "aiohttp-socks", specifier = ">=0.11.0" },
     { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "anyio", specifier = ">=4.12.1" },
     { name = "asyncclick", specifier = ">=8.1.7.2" },


### PR DESCRIPTION
- New `[proxy]` config section supports a global fallback URL and per-service overrides
- Supports HTTP, HTTPS, SOCKS4, SOCKS4A, and SOCKS5 with optional auth embedded in the URL
- Per-service key disables the global proxy when set to an empty string
- Covered services: RED, OPS, DIC, Qobuz, Tidal, Bandcamp, Deezer, Beatport, Discogs, Apple Music, ptpimg, ptscreens, oeimg, imgbb, catbox
- imgbox is excluded - its upload flow doesn't go through aiohttp in a way that's easy to intercept