### PR TITLE
Add Ra (thesungod.xyz) image host support

### DIFF
--- a/src/salmon/config/validations.py
+++ b/src/salmon/config/validations.py
@@ -24,7 +24,7 @@ class Directory(BaseStruct):
             raise ValueError("tmp_dir is not a valid directory")
 
 
-ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "imgbb", "imgbox"]
+ImgUploaderLiteral = Literal["ptpimg", "ptscreens", "oeimg", "catbox", "imgbb", "imgbox", "ra"]
 SpectralSelectionLiteral = Literal["*", "+", "0"]
 
 
@@ -36,6 +36,7 @@ class ImageUploader(BaseStruct):
     ptscreens_key: str | None = None
     oeimg_key: str | None = None
     imgbb_key: str | None = None
+    ra_key: str | None = None
     remove_auto_downloaded_cover_image: bool = False
     auto_compress_cover: bool = False
     default_spectral_ids: SpectralSelectionLiteral | None = None
@@ -50,6 +51,11 @@ class ImageUploader(BaseStruct):
             raise ValueError("oeimage key not specified")
         if "imgbb" in uploader_selections and self.imgbb_key is None:
             raise ValueError("imgbb key not specified")
+        if "ra" in uploader_selections and self.ra_key is None:
+            raise ValueError("ra key not specified")
+        # ra does not allow spectral uploads
+        if self.specs_uploader == "ra":
+            raise ValueError("Ra does not support spectral uploads")
 
 
 class TidalSettings(BaseStruct):

--- a/src/salmon/data/config.default.toml
+++ b/src/salmon/data/config.default.toml
@@ -28,7 +28,8 @@ dottorrents_dir = '.torrents'
 # ===============================
 # IMAGE UPLOAD SETTINGS
 # ===============================
-# Image hosters: ptpimg, ptscreens, oeimg, imgbb, catbox, imgbox
+# Image hosters: ptpimg, ptscreens, oeimg, imgbb, catbox, imgbox, ra
+# Note: ra (thesungod.xyz) cannot be used as specs_uploader
 [image]
 image_uploader = "ptpimg"
 cover_uploader = "ptpimg"
@@ -46,6 +47,8 @@ ptscreens_key = 'api_key'
 oeimg_key = 'api_key'
 # imgbb API key (log into imgbb, about, API)
 imgbb_key = 'api_key'
+# ra API key (log into ra, settings, API keys)
+ra_key = 'api_key'
 
 # Set to true to remove downloaded cover images that are created in source folder, when one does not exist
 # remove_auto_downloaded_cover_image = false

--- a/src/salmon/images/__init__.py
+++ b/src/salmon/images/__init__.py
@@ -7,7 +7,7 @@ import pyperclip
 from salmon import cfg
 from salmon.common import AliasedCommands, commandgroup
 from salmon.errors import ImageUploadFailed
-from salmon.images import catbox, imgbb, imgbox, oeimg, ptpimg, ptscreens
+from salmon.images import catbox, imgbb, imgbox, oeimg, ptpimg, ptscreens, ra
 
 HOSTS = {
     "ptpimg": ptpimg,
@@ -16,6 +16,7 @@ HOSTS = {
     "oeimg": oeimg,
     "imgbb": imgbb,
     "imgbox": imgbox,
+    "ra": ra,
 }
 
 

--- a/src/salmon/images/ra.py
+++ b/src/salmon/images/ra.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import aiohttp
+import anyio
+import msgspec
+
+from salmon import cfg
+from salmon.errors import ImageUploadFailed
+from salmon.images.base import BaseImageUploader
+
+UPLOAD_URL = "https://thesungod.xyz/api/image/upload"
+
+
+class ImageUploader(BaseImageUploader):
+    """Image uploader for thesungod.xyz (Ra)."""
+
+    async def upload_file(self, filename: str) -> tuple[str, None]:
+        """Upload image file to thesungod.xyz.
+
+        Args:
+            filename: Path to the image file.
+
+        Returns:
+            Tuple of (url, deletion_url).
+
+        Raises:
+            ImageUploadFailed: If upload fails.
+        """
+        async with await anyio.open_file(filename, "rb") as f:
+            file_data = await f.read()
+
+        data = aiohttp.FormData()
+        data.add_field("api_key", cfg.image.ra_key)
+        data.add_field("image", file_data, filename=Path(filename).name)
+
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.post(UPLOAD_URL, data=data) as resp,
+            ):
+                resp.raise_for_status()
+                r = await resp.json(loads=msgspec.json.decode)
+                return r["links"][0], None
+        except (msgspec.DecodeError, KeyError, IndexError) as e:
+            raise ImageUploadFailed(f"Failed decoding body: {e}") from e
+        except aiohttp.ClientError as e:
+            raise ImageUploadFailed(f"Network error: {e}") from e


### PR DESCRIPTION
Adds support for [Ra](https://thesungod.xyz/) as an image host for cover and general image uploads.

**Changes**
`src/salmon/images/ra.py` — New uploader implementation. Posts to `https://thesungod.xyz/api/image/upload` with `api_key` and `image` fields, parses the `links` array from the JSON response.
`src/salmon/images/__init__.py` — Registers `ra` in the `HOSTS` dict and import list.
`src/salmon/config/validations.py` — Adds `ra` to `ImgUploaderLiteral`, adds `ra_key` config field, and validates that `specs_uploader` is not set to `ra`.
`src/salmon/data/config.default.toml` — Documents `ra` as an available host and adds the `ra_key` config entry.

**Notes**
Spectral uploads to Ra are intentionally unsupported. Setting `specs_uploader = "ra"` in the config will raise a `ValueError` at startup with a clear message.

To use Ra, add the following to your config:
`ra_key = 'api_key'`
 
 #408 