### PR TITLE
fix(qobuz): map epmini release type to EP

### DIFF
--- a/src/salmon/tagger/sources/qobuz.py
+++ b/src/salmon/tagger/sources/qobuz.py
@@ -24,6 +24,7 @@ RE_SOUNDTRACK = re.compile(r"original.*soundtrack", re.IGNORECASE)
 RECORD_TYPES = {
     "album": "Album",
     "ep": "EP",
+    "epmini": "EP",
     "single": "Single",
 }
 


### PR DESCRIPTION
Qobuz's API returns `release_type: "epmini"` for EPs, but `RECORD_TYPES` in `src/salmon/tagger/sources/qobuz.py` only maps `album`, `ep`, and `single` — so every Qobuz EP falls through the direct mapping and gets classified as **Album** unless its title happens to contain "EP".

One-line fix: add the `epmini` → `EP` mapping.

Verified in production use: with this mapping, salmon auto-sets `RELEASE TYPE: EP` for Qobuz EP releases that previously came through as Album (e.g. observed live on a Qobuz `epmini` release where the patched build set EP correctly).

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)