### PR TITLE
Reuse one kept-alive tracker connection per API instance

### DIFF
--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -170,10 +170,33 @@ class BaseGazelleApi:
         self.authkey: str | None = None
         self.passkey: str | None = None
         self._authenticated = False
+        self._session: aiohttp.ClientSession | None = None
 
     def _get_cookies(self) -> dict[str, str]:
         """Get cookies dict for requests."""
         return {"session": self.cookie}
+
+    def _http_session(self) -> aiohttp.ClientSession:
+        """Get the persistent HTTP session for this API instance."""
+        if self._session is None or self._session.closed:
+            # One connection, so gathered calls cannot burst simultaneous TLS
+            # handshakes from one IP and read as scanner traffic to tracker edges.
+            # Per instance, as a ClientSession binds to the running loop.
+            # DummyCookieJar keeps nothing between requests, so an api-key request
+            # still goes out without a session cookie.
+            self._session = aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(limit=1),
+                cookie_jar=aiohttp.DummyCookieJar(),
+            )
+            with suppress(RuntimeError):
+                click.get_current_context().call_on_close(self.close)
+        return self._session
+
+    async def close(self) -> None:
+        """Close the persistent HTTP session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
 
     @property
     def announce(self) -> str:
@@ -247,10 +270,18 @@ class BaseGazelleApi:
 
         try:
             timeout = aiohttp.ClientTimeout(total=timeout_secs)
+            session = self._http_session()
             async with (
                 self._rate_limiter,
-                aiohttp.ClientSession(timeout=timeout, cookies=cookies, headers=headers) as session,
-                session.request(method, url, params=params, data=data) as resp,
+                session.request(
+                    method,
+                    url,
+                    params=params,
+                    data=data,
+                    headers=headers,
+                    cookies=cookies,
+                    timeout=timeout,
+                ) as resp,
             ):
                 text = await resp.text()
 

--- a/src/salmon/trackers/base.py
+++ b/src/salmon/trackers/base.py
@@ -12,7 +12,7 @@ import msgspec
 from aiohttp import FormData
 from aiolimiter import AsyncLimiter
 from bs4 import BeautifulSoup
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_random
 
 from salmon import cfg
 from salmon.common import UploadFiles
@@ -229,7 +229,9 @@ class BaseGazelleApi:
     @retry(
         retry=retry_if_exception_type(RetryableError),
         stop=stop_after_attempt(5),
-        wait=wait_fixed(1),
+        # Backing off beats hammering at a fixed 1s, and the random term keeps a
+        # batch that fails together from retrying in one synchronized salvo.
+        wait=wait_exponential(multiplier=1, min=1, max=30) + wait_random(0, 2),
         reraise=True,
     )
     async def _request(

--- a/tests/test_trackers_session.py
+++ b/tests/test_trackers_session.py
@@ -1,0 +1,96 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import anyio
+from aiohttp import web
+from aiolimiter import AsyncLimiter
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from salmon.trackers.base import BaseGazelleApi
+
+
+class FakeApi(BaseGazelleApi):
+    cookie = "fake-cookie"
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+        super().__init__()
+        # Shadow the 5-per-10s limiter so the tests measure connection reuse, not
+        # throttling. Per instance, as each test runs on its own event loop.
+        self._rate_limiter = AsyncLimiter(100, 1)
+        self._authenticated = True
+
+
+async def _serve(handler) -> web.AppRunner:
+    app = web.Application()
+    app.router.add_get("/ajax.php", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    await web.TCPSite(runner, "127.0.0.1", 0).start()
+    return runner
+
+
+def _url(runner: web.AppRunner, host: str = "127.0.0.1") -> str:
+    return f"http://{host}:{runner.addresses[0][1]}"
+
+
+def _ok() -> web.Response:
+    return web.json_response({"status": "success", "response": {"authkey": "a", "passkey": "p"}})
+
+
+async def _gathered_requests_share_one_connection() -> None:
+    peers = []
+
+    async def handle_ajax(request: web.Request) -> web.Response:
+        peers.append(request.transport.get_extra_info("peername"))
+        return _ok()
+
+    runner = await _serve(handle_ajax)
+    api = FakeApi(_url(runner))
+    try:
+        await asyncio.gather(
+            *(
+                api._request("GET", api.base_url + "/ajax.php", params={"action": "index"}, timeout_secs=10)
+                for _ in range(6)
+            )
+        )
+        assert len(peers) == 6
+        assert len({peer[1] for peer in peers}) == 1
+    finally:
+        await api.close()
+        await runner.cleanup()
+
+
+async def _api_key_requests_stay_cookie_free() -> None:
+    sent_cookies = []
+
+    async def handle_ajax(request: web.Request) -> web.Response:
+        sent_cookies.append(request.headers.get("Cookie"))
+        response = _ok()
+        response.set_cookie("planted", "by-the-server")
+        return response
+
+    runner = await _serve(handle_ajax)
+    # A named host, because a cookie jar discards cookies set by a bare IP address.
+    api = FakeApi(_url(runner, "localhost"))
+    api.api_key = "an-api-key"
+    try:
+        url = api.base_url + "/ajax.php"
+        await api._request("GET", url, params={"action": "index"})
+        await api._request("GET", url, params={"action": "index"}, prefer_api_key=True)
+        assert "session=fake-cookie" in sent_cookies[0]
+        # The shared session must not carry the server's cookie into a request that
+        # authenticates by api key, which is meant to send no cookie at all.
+        assert sent_cookies[1] is None
+    finally:
+        await api.close()
+        await runner.cleanup()
+
+
+def test_gathered_requests_share_one_connection() -> None:
+    anyio.run(_gathered_requests_share_one_connection)
+
+
+def test_api_key_requests_stay_cookie_free() -> None:
+    anyio.run(_api_key_requests_stay_cookie_free)


### PR DESCRIPTION
`BaseGazelleApi._request` opened a fresh `aiohttp.ClientSession` per request, so gathered calls (`get_search_results`, `get_uploads_from_log`) burst one TLS handshake per request from a single IP. That connection shape reads as scanner traffic to tracker edge protection, which answers with a temporary source-IP refusal. This does not close #432 — it changes the connection shape, not the request count.

The first commit holds one session per instance behind `TCPConnector(limit=1)`, closed via the click context. Per-request timeout/headers/cookies and a `DummyCookieJar` keep the previous request semantics, so an api-key request still sends no cookie. The second commit replaces `wait_fixed(1)` with exponential backoff plus jitter so a batch that fails together stops retrying in lockstep; the attempt count is unchanged. It is independent — happy to drop it if you would rather leave the retry policy alone.

`tests/test_trackers_session.py` asserts that 6 gathered requests ride one TCP connection, and that an api-key request sends no cookie over the shared session. Both fail if the connector cap or the cookie jar is removed.

Smoke-tested against live trackers from an image built off this branch: OPS passes both the session-cookie and api-key checks, RED passes the api-key check. RED's session-cookie check fails identically on stock master, so it is unrelated (it reproduces #361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
